### PR TITLE
Fix CS-42-S: obligations were transposed between parents

### DIFF
--- a/src/FairShare.Domain/Calculators/CS42SCalculator.cs
+++ b/src/FairShare.Domain/Calculators/CS42SCalculator.cs
@@ -62,7 +62,14 @@ namespace FairShare.Domain.Calculators
                 int plaintiffRecommendedObligation = plaintiffBasicObligation - (int)Math.Round(plaintiffTotalCostsPaid * defendantIncomePercentage, 0);
                 int defendantRecommendedObligation = defendantBasicObligation - (int)Math.Round(defendantTotalCostsPaid * plaintiffIncomePercentage, 0);
 
-                if (plaintiffRecommendedObligation > defendantRecommendedObligation)
+                if (plaintiffRecommendedObligation == defendantRecommendedObligation)
+                {
+                    // An empty payer is the UI's signal for "No net transfer." - naming a
+                    // parent with a $0 amount would read as a real (if empty) obligation.
+                    result.Payer = string.Empty;
+                    result.FinalAmount = 0;
+                }
+                else if (plaintiffRecommendedObligation > defendantRecommendedObligation)
                 {
                     result.Payer = Enums.ParentType.Plaintiff.ToString();
                     result.FinalAmount = plaintiffRecommendedObligation - defendantRecommendedObligation;

--- a/src/FairShare.Domain/Calculators/CS42SCalculator.cs
+++ b/src/FairShare.Domain/Calculators/CS42SCalculator.cs
@@ -49,8 +49,12 @@ namespace FairShare.Domain.Calculators
                 int plaintiffSharedParentingObligation = (int)Math.Round(sharedParentingObligation * plaintiffIncomePercentage, 0);
                 int defendantSharedParentingObligation = (int)Math.Round(sharedParentingObligation * defendantIncomePercentage, 0);
 
-                int plaintiffBasicObligation = (int)Math.Round(defendantSharedParentingObligation * 0.5, 0);
-                int defendantBasicObligation = (int)Math.Round(plaintiffSharedParentingObligation * 0.5, 0);
+                // Per the CS-42-S worksheet, each parent owes their OWN income-share of the
+                // shared-parenting obligation, prorated by the time the children spend with
+                // the other parent (50/50 custody assumed). These were previously transposed,
+                // which made the lower-earning parent always come out as the payer.
+                int plaintiffBasicObligation = (int)Math.Round(plaintiffSharedParentingObligation * 0.5, 0);
+                int defendantBasicObligation = (int)Math.Round(defendantSharedParentingObligation * 0.5, 0);
 
                 int plaintiffTotalCostsPaid = plaintiff.GetTotalChildcareAndHealthcareCosts();
                 int defendantTotalCostsPaid = defendant.GetTotalChildcareAndHealthcareCosts();

--- a/src/FairShare.Tests/Domain/CS42SCalculatorTests.cs
+++ b/src/FairShare.Tests/Domain/CS42SCalculatorTests.cs
@@ -1,0 +1,59 @@
+using FairShare.Domain.Calculators;
+using FairShare.Domain.Helpers;
+using FairShare.Domain.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FairShare.Tests.Domain;
+
+public class CS42SCalculatorTests
+{
+    private readonly CS42SCalculator _calculator = new(NullLogger<CS42SCalculator>.Instance);
+
+    // Regression for the transposed-obligation bug: each parent's obligation was computed
+    // from the OTHER parent's income share, so the lower earner always came out as the
+    // payer (this exact scenario reported Plaintiff owing $786).
+    [Fact]
+    public void Calculate_HigherEarningDefendant_DefendantPays()
+    {
+        ParentData plaintiff = new()
+        {
+            MonthlyGrossIncome = 4244
+        };
+
+        ParentData defendant = new()
+        {
+            MonthlyGrossIncome = 9173,
+            HealthcareCoverageCosts = 195
+        };
+
+        CalculationResult result = _calculator.Calculate(plaintiff, defendant, numberOfChildren: 4);
+
+        // BCSO(13400, 4) = 2680; x1.5 = 4020; shares 0.32/0.68 -> 1286/2734.
+        // Own share x 50% custody: plaintiff 643, defendant 1367.
+        // Defendant's healthcare credit: 195 x 0.32 = 62 -> defendant owes 1305 - 643 = 662.
+        Assert.True(result.Success);
+        Assert.Equal("Defendant", result.Payer);
+        Assert.Equal(662, result.FinalAmount);
+    }
+
+    [Fact]
+    public void Calculate_IdenticalParents_NoNetTransfer()
+    {
+        ParentData plaintiff = new() { MonthlyGrossIncome = 5000, HealthcareCoverageCosts = 100 };
+        ParentData defendant = new() { MonthlyGrossIncome = 5000, HealthcareCoverageCosts = 100 };
+
+        CalculationResult result = _calculator.Calculate(plaintiff, defendant, numberOfChildren: 2);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.FinalAmount);
+    }
+
+    [Fact]
+    public void Calculate_ZeroChildren_ReturnsValidationError()
+    {
+        CalculationResult result = _calculator.Calculate(new ParentData(), new ParentData(), numberOfChildren: 0);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Code == "INVALID_CHILD_COUNT");
+    }
+}

--- a/src/FairShare.Tests/Domain/CS42SCalculatorTests.cs
+++ b/src/FairShare.Tests/Domain/CS42SCalculatorTests.cs
@@ -46,6 +46,9 @@ public class CS42SCalculatorTests
 
         Assert.True(result.Success);
         Assert.Equal(0, result.FinalAmount);
+        // The UI renders "No net transfer." only when the payer is blank - a named payer
+        // with a $0 amount would display as a misleading "X owes $0".
+        Assert.True(string.IsNullOrWhiteSpace(result.Payer));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The CS-42-S (shared custody) calculator computed each parent's basic obligation from the **other** parent's income-share of the shared-parenting obligation. Since each parent's obligation is their own share × the other parent's 50% custody period, the transposition made the lower-earning parent always come out as the payer.

**Reported scenario** (plaintiff $4,244, defendant $9,173, $195 healthcare on the defendant, 4 children): showed the plaintiff owing **$786**. After the fix, the defendant owes **$662**:

| Step | Value |
|---|---|
| BCSO(13,400, 4 children) | 2,680 |
| ×1.5 shared-parenting obligation | 4,020 |
| Income shares (0.32 / 0.68) | 1,286 / 2,734 |
| Own share × 50% custody | 643 / 1,367 |
| Defendant's healthcare credit (195 × 0.32) | −62 |
| Net: defendant pays 1,305 − 643 | **$662** |

The old math reproduced the reported $786 exactly (1,367 − (643 − 62)), confirming the diagnosis.

## Testing

- New `CS42SCalculatorTests`: the reported scenario (expects Defendant/$662), an identical-parents symmetry case (no net transfer), and zero-children validation. The CS-42-S calculator previously had **no** unit tests, which is how this survived.
- Full suite: 18/18 green.

## Notes

The calculator assumes 50/50 custody time — CS-42-S's per-parent overnights input is not yet modeled. That's a pre-existing feature gap, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)