### PR TITLE
feat: update saved parents in place when re-saved under an existing name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FairShare gives a quick, transparent estimate of who pays child support and how 
   - CS-42-S (Shared Parenting/SPCA) calculations.
 - **Responsive UI**: Two-column layout optimized for both desktop and mobile (Bootstrap 5).
 - **Theme Support**: Light/Dark/Auto theme toggle.
-- **Data Persistence**: Save and manage Parent Profiles (Plaintiff vs Defendant).
+- **Data Persistence**: Save and manage Parent Profiles (Plaintiff vs Defendant). Within your saved parents the display name is the natural key: re-saving an existing name (even with adjusted figures) updates that record in place instead of creating a same-named duplicate.
 - **Admin Tools**: Comprehensive user management and automated database seeding.
 - **Health & Safety**: Integrated database integrity checks and automated backup zipping on startup.
 - **Guest mode**: Try the calculator without creating an account (no saving).


### PR DESCRIPTION
## Summary

Documents the saved-parents upsert behavior (shipped in #60) in the README's feature list.

This PR's conventional-commit title also serves a second purpose: release-please could not parse #60's squash title (`Update saved parents in place... (#60)` — no `feat:` prefix), so it found zero releasable commits since 7.0.1 and skipped the release PR. Squash-merging this PR with its `feat:` title lets release-please propose the next minor version (7.1.0) covering the feature.

Going forward: since squash titles come from PR titles, giving PRs conventional-commit titles (`feat:`/`fix:`/`chore:`) keeps release-please working automatically.

## Testing

Docs-only; CI build/test still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)