### PR TITLE
feat!: public hardening - rate limiting, registration gate, password management, CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,21 @@ JWT_SIGNING_KEY=
 
 # Initial admin account, seeded on first run.
 # Leave ADMIN_PASSWORD empty to generate a random one (printed in `docker compose logs api`).
+# Docker keeps container logs on disk, so treat a generated password as burned: log in,
+# change it from the Account page, then set ADMIN_SEED_ENABLED=false.
 ADMIN_USER=admin
 ADMIN_PASSWORD=
+
+# Set to false after the first successful boot - the seeder only matters once, and
+# admin credentials have no reason to linger in this file afterwards.
+ADMIN_SEED_ENABLED=true
+
+# Whether a generated admin password is printed to the api container log.
+ADMIN_SEED_LOG_GENERATED_PASSWORD=true
+
+# Self-registration is off by default: the admin creates accounts (Admin > Users).
+# Set to true to let anyone with access to the site register their own account.
+ALLOW_SELF_REGISTRATION=false
 
 # Host ports (browser-visible).
 WEB_PORT=5858

--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ If `ADMIN_PASSWORD` was left empty, the generated admin password is printed once
 
 Both images build from source — no registry needed. Ports and browser-visible URLs are configurable in `.env` (`WEB_PORT`/`API_PORT`/`WEB_ORIGIN`/`API_BASE_URL`).
 
-**Hosting behind a reverse proxy (VPS):** terminate TLS at your proxy and forward `X-Forwarded-Proto` (the API honors it for cookie security attributes), set `WEB_ORIGIN` to the web app's public URL (CORS) and `API_BASE_URL` to the API's public URL. `API_BASE_URL` must always be the *browser-visible* API URL, never the compose-internal service name.
+**Hosting behind a reverse proxy (VPS):** terminate TLS at your proxy and forward `X-Forwarded-Proto` (the API honors it for cookie security attributes), set `WEB_ORIGIN` to the web app's public URL (CORS) and `API_BASE_URL` to the API's public URL. `API_BASE_URL` must always be the *browser-visible* API URL, never the compose-internal service name. Note that rate limiting keys on the direct peer IP: behind a reverse proxy every client collapses into the proxy's bucket. That is deliberate — trusting `X-Forwarded-For` without pinning the proxy in `KnownProxies` would let clients spoof their way out of throttling — so pin your proxy before switching the limiter to forwarded addresses.
+
+### Hardening a public instance
+
+- **Self-registration is disabled by default** (`ALLOW_SELF_REGISTRATION=false`): create accounts from **Admin → Users**. Only enable it if you want strangers to be able to sign up.
+- **Admin bootstrap:** set a strong `ADMIN_PASSWORD` in `.env` before first boot. If you let the seeder generate one, treat it as burned — Docker persists container logs — so log in, change it from the **Account** page, and consider renaming the account (`ADMIN_USER`); every credential-stuffing bot tries `admin` first.
+- **After first boot**, set `ADMIN_SEED_ENABLED=false` and remove `ADMIN_PASSWORD` from `.env` — the seeder only matters once.
+- **Signing key:** generate a fresh `JWT_SIGNING_KEY` for production (`openssl rand -base64 48`); never reuse a key that has been committed anywhere. Rotating it only invalidates outstanding access tokens (≤30 min); sessions recover silently via the refresh cookie.
+- **Passwords:** users change their own via **Account → Change password**; admins reset others' via **Admin → Users → Edit**. Both revoke all of that user's refresh tokens.
 
 ---
 
@@ -136,9 +144,12 @@ Swagger UI is available at `/swagger` in Development.
 | `Jwt:AccessTokenMinutes`            | `30`         | Access token lifetime.                                                                 |
 | `Jwt:RefreshTokenDays`              | `30`         | Refresh token lifetime.                                                                |
 | `Cors:AllowedOrigins`               | `[]`         | Origins allowed to call the API (the Web app's URL).                                   |
-| `AdminSeed:Enabled`                 | `true`       | Enables seeding the initial admin account.                                             |
+| `AdminSeed:Enabled`                 | `true`       | Enables seeding the initial admin account. Disable after first boot.                   |
 | `AdminSeed:User`                    | `admin`      | Username for the initial admin.                                                        |
 | `AdminSeed:Password`                | *(random)*   | Password for the initial admin (logged on first run if empty).                         |
+| `AdminSeed:LogGeneratedPassword`    | `true`       | Whether a generated admin password is printed to the log.                              |
+| `Auth:AllowSelfRegistration`        | `false`      | Whether `POST /api/v1/auth/register` is open. Off = admin creates accounts.            |
+| `RateLimiting:Enabled`              | `true`       | Kill-switch for rate limiting (values are fixed: 100 req/min per IP globally, 10 req/min per IP on the auth endpoints). |
 
 | Setting (Web)     | Default | Purpose                                    |
 | ------------------ | ------- | ------------------------------------------ |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,3 +4,16 @@ If you believe you’ve found a security vulnerability in FairShare, please do *
 Instead, email: theguywiththedogs.dev@gmail.com with details and a proof of concept if possible.
 
 I will do my best to respond within 7 days.
+
+## Baseline hardening
+
+For context when assessing reports, a deployed instance already includes: JWT bearer
+auth with short-lived access tokens; single-use rotating refresh tokens (hashed at
+rest, HttpOnly cookie, revoked in bulk on password change/reset, stale rows purged
+periodically); login lockout with uniform 401 responses; per-IP rate limiting with a
+stricter budget on the auth endpoints; self-registration disabled by default; CORS
+pinned to configured origins; and CSP/security headers on the web container.
+
+Known accepted trade-off: outstanding access tokens (up to `Jwt:AccessTokenMinutes`,
+default 30) remain valid after a password change or reset - JWTs are not
+security-stamp-validated per request.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,11 @@ services:
       ConnectionStrings__Default: "Data Source=/data/fairshare.db"
       # Required - fail fast at compose time rather than at container startup.
       Jwt__SigningKey: "${JWT_SIGNING_KEY:?Set JWT_SIGNING_KEY in .env (see .env.example)}"
-      AdminSeed__Enabled: "true"
+      AdminSeed__Enabled: "${ADMIN_SEED_ENABLED:-true}"
       AdminSeed__User: "${ADMIN_USER:-admin}"
       AdminSeed__Password: "${ADMIN_PASSWORD:-}"
-      AdminSeed__LogGeneratedPassword: "true"
+      AdminSeed__LogGeneratedPassword: "${ADMIN_SEED_LOG_GENERATED_PASSWORD:-true}"
+      Auth__AllowSelfRegistration: "${ALLOW_SELF_REGISTRATION:-false}"
       Cors__AllowedOrigins__0: "${WEB_ORIGIN:-http://localhost:5858}"
     volumes:
       - fairshare-data:/data

--- a/src/FairShare.Api/Auth/ITokenService.cs
+++ b/src/FairShare.Api/Auth/ITokenService.cs
@@ -17,4 +17,6 @@ public interface ITokenService
     Task<IssuedRefreshToken> IssueRefreshTokenAsync(Guid? userId, bool isGuest, CancellationToken ct = default);
 
     Task<RefreshToken?> ConsumeRefreshTokenAsync(string rawToken, CancellationToken ct = default);
+
+    Task<int> RevokeAllForUserAsync(Guid userId, CancellationToken ct = default);
 }

--- a/src/FairShare.Api/Auth/TokenService.cs
+++ b/src/FairShare.Api/Auth/TokenService.cs
@@ -96,6 +96,15 @@ public class TokenService(FairShareDbContext db, IOptions<JwtOptions> jwtOptions
         return await _db.RefreshTokens.FirstOrDefaultAsync(t => t.TokenHash == hash, ct);
     }
 
+    public async Task<int> RevokeAllForUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        DateTime now = DateTime.UtcNow;
+
+        return await _db.RefreshTokens
+            .Where(t => t.UserId == userId && t.RevokedUtc == null)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.RevokedUtc, now), ct);
+    }
+
     private static string GenerateRawToken()
     {
         byte[] bytes = RandomNumberGenerator.GetBytes(32);

--- a/src/FairShare.Api/Controllers/AuthController.cs
+++ b/src/FairShare.Api/Controllers/AuthController.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
 
 namespace FairShare.Api.Controllers;
 
@@ -17,18 +20,34 @@ namespace FairShare.Api.Controllers;
 public class AuthController(
     UserManager<ApplicationUser> userManager,
     SignInManager<ApplicationUser> signInManager,
-    ITokenService tokenService) : ControllerBase
+    ITokenService tokenService,
+    IOptions<AuthOptions> authOptions) : ControllerBase
 {
     private const string RefreshCookieName = "fairshare_refresh";
 
     private readonly UserManager<ApplicationUser> _userManager = userManager;
     private readonly SignInManager<ApplicationUser> _signInManager = signInManager;
     private readonly ITokenService _tokenService = tokenService;
+    private readonly AuthOptions _authOptions = authOptions.Value;
+
+    [HttpGet("config")]
+    [AllowAnonymous]
+    public ActionResult<AuthConfigResponse> GetConfig() =>
+        Ok(new AuthConfigResponse { AllowSelfRegistration = _authOptions.AllowSelfRegistration });
 
     [HttpPost("register")]
     [AllowAnonymous]
+    [EnableRateLimiting("auth")]
     public async Task<IActionResult> Register([FromBody] RegisterRequest request, CancellationToken ct)
     {
+        // No information leak: whether registration is open is public via GET config.
+        if (!_authOptions.AllowSelfRegistration)
+        {
+            return Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                title: "Self-registration is disabled on this server.");
+        }
+
         ApplicationUser user = new()
         {
             UserName = request.UserName,
@@ -52,6 +71,7 @@ public class AuthController(
 
     [HttpPost("login")]
     [AllowAnonymous]
+    [EnableRateLimiting("auth")]
     public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken ct)
     {
         ApplicationUser? user = await _userManager.FindByNameAsync(request.UserName);
@@ -73,10 +93,12 @@ public class AuthController(
 
     [HttpPost("guest")]
     [AllowAnonymous]
+    [EnableRateLimiting("auth")]
     public async Task<IActionResult> Guest(CancellationToken ct) => await IssueGuestTokensAsync(ct);
 
     [HttpPost("refresh")]
     [AllowAnonymous]
+    [EnableRateLimiting("auth")]
     public async Task<IActionResult> Refresh(CancellationToken ct)
     {
         if (!Request.Cookies.TryGetValue(RefreshCookieName, out string? rawRefreshToken) || string.IsNullOrWhiteSpace(rawRefreshToken))
@@ -121,6 +143,35 @@ public class AuthController(
 
         ClearRefreshCookie();
         return NoContent();
+    }
+
+    [HttpPost("change-password")]
+    [Authorize(Policy = "NotGuest")]
+    public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request, CancellationToken ct)
+    {
+        string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        ApplicationUser? user = userId is null ? null : await _userManager.FindByIdAsync(userId);
+
+        if (user is null || user.IsDisabled)
+        {
+            return Unauthorized();
+        }
+
+        IdentityResult result = await _userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
+
+        if (!result.Succeeded)
+        {
+            return ValidationProblem(new ValidationProblemDetails(
+                result.Errors
+                    .GroupBy(e => e.Code)
+                    .ToDictionary(g => g.Key, g => g.Select(e => e.Description).ToArray())));
+        }
+
+        // Kill every other session, then re-issue for this one so the caller stays
+        // signed in while stolen/old refresh tokens die immediately.
+        await _tokenService.RevokeAllForUserAsync(user.Id, ct);
+
+        return await IssueTokensAsync(user, ct);
     }
 
     private async Task<IActionResult> IssueGuestTokensAsync(CancellationToken ct)

--- a/src/FairShare.Api/Controllers/UsersController.cs
+++ b/src/FairShare.Api/Controllers/UsersController.cs
@@ -131,22 +131,34 @@ public class UsersController(UserManager<ApplicationUser> um, RoleManager<Identi
 
         if (!result.Succeeded)
         {
-            return ValidationProblem(new ValidationProblemDetails(
-                result.Errors
-                    .GroupBy(e => e.Code)
-                    .ToDictionary(g => g.Key, g => g.Select(e => e.Description).ToArray())));
+            return IdentityValidationProblem(result);
         }
 
-        await _userManager.SetLockoutEndDateAsync(user, null);
+        IdentityResult lockoutResult = await _userManager.SetLockoutEndDateAsync(user, null);
+        if (!lockoutResult.Succeeded)
+        {
+            return IdentityValidationProblem(lockoutResult);
+        }
 
         user.UpdatedUtc = DateTime.UtcNow;
         user.UpdatedByUserId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
-        await _userManager.UpdateAsync(user);
+
+        IdentityResult updateResult = await _userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            return IdentityValidationProblem(updateResult);
+        }
 
         await _tokenService.RevokeAllForUserAsync(user.Id, ct);
 
         return NoContent();
     }
+
+    private ActionResult IdentityValidationProblem(IdentityResult result) =>
+        ValidationProblem(new ValidationProblemDetails(
+            result.Errors
+                .GroupBy(e => e.Code)
+                .ToDictionary(g => g.Key, g => g.Select(e => e.Description).ToArray())));
 
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteUser(Guid id)

--- a/src/FairShare.Api/Controllers/UsersController.cs
+++ b/src/FairShare.Api/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using FairShare.Api.Auth;
 using FairShare.Api.Models;
 using FairShare.Contracts.Admin;
 using Microsoft.AspNetCore.Authorization;
@@ -15,10 +16,11 @@ namespace FairShare.Api.Controllers;
 [Authorize(Policy = "AdminOnly")]
 [ApiController]
 [Route("api/v1/admin/users")]
-public class UsersController(UserManager<ApplicationUser> um, RoleManager<IdentityRole<Guid>> rm) : ControllerBase
+public class UsersController(UserManager<ApplicationUser> um, RoleManager<IdentityRole<Guid>> rm, ITokenService tokenService) : ControllerBase
 {
     private readonly UserManager<ApplicationUser> _userManager = um;
     private readonly RoleManager<IdentityRole<Guid>> _roleManager = rm;
+    private readonly ITokenService _tokenService = tokenService;
 
     [HttpGet]
     public async Task<ActionResult<IEnumerable<UserListItem>>> GetUsers(string filter = "all")
@@ -109,6 +111,39 @@ public class UsersController(UserManager<ApplicationUser> um, RoleManager<Identi
             await _userManager.RemoveFromRolesAsync(user, existingRoles);
             await _userManager.AddToRoleAsync(user, model.Role);
         }
+
+        return NoContent();
+    }
+
+    // Self-reset is allowed on purpose: unlike self-delete it cannot lock the admin out
+    // (they chose the new password), and killing their other sessions is the intended
+    // semantics of a reset.
+    [HttpPost("{id}/reset-password")]
+    public async Task<IActionResult> ResetPassword(Guid id, AdminResetPasswordRequest model, CancellationToken ct)
+    {
+        var user = await _userManager.FindByIdAsync(id.ToString());
+        if (user is null) return NotFound();
+
+        // Token-based reset keeps a single validation path and cannot strand the user
+        // password-less the way RemovePassword+AddPassword can.
+        string resetToken = await _userManager.GeneratePasswordResetTokenAsync(user);
+        IdentityResult result = await _userManager.ResetPasswordAsync(user, resetToken, model.NewPassword);
+
+        if (!result.Succeeded)
+        {
+            return ValidationProblem(new ValidationProblemDetails(
+                result.Errors
+                    .GroupBy(e => e.Code)
+                    .ToDictionary(g => g.Key, g => g.Select(e => e.Description).ToArray())));
+        }
+
+        await _userManager.SetLockoutEndDateAsync(user, null);
+
+        user.UpdatedUtc = DateTime.UtcNow;
+        user.UpdatedByUserId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        await _userManager.UpdateAsync(user);
+
+        await _tokenService.RevokeAllForUserAsync(user.Id, ct);
 
         return NoContent();
     }

--- a/src/FairShare.Api/Models/AuthOptions.cs
+++ b/src/FairShare.Api/Models/AuthOptions.cs
@@ -1,17 +1,8 @@
-using System.Threading;
-using System.Threading.Tasks;
-using System.Linq;
-using System.Collections.Generic;
-using System;
 namespace FairShare.Api.Models;
 
 public class AuthOptions
 {
-    public bool AllowSelfRegistration { get; set; } = true;
+    // Off by default: a freshly deployed instance should not accept strangers'
+    // sign-ups until the operator opts in (Auth:AllowSelfRegistration).
+    public bool AllowSelfRegistration { get; set; } = false;
 }
-
-
-
-
-
-

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -178,7 +178,7 @@ builder.Services.AddRateLimiter(options =>
 
     options.OnRejected = (ctx, _) =>
     {
-        ctx.HttpContext.Response.Headers.RetryAfter = "60";
+        ctx.HttpContext.Response.Headers["Retry-After"] = "60";
         return ValueTask.CompletedTask;
     };
 });

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -9,6 +9,7 @@ using System;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using FairShare.Api.Auth;
@@ -87,6 +88,8 @@ builder.Services.AddOptions<JwtOptions>()
 
 builder.Services.Configure<AdminSeedOptions>(builder.Configuration.GetSection("AdminSeed"));
 
+builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection("Auth"));
+
 builder.Services.AddAuthentication(options =>
     {
         options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -139,6 +142,47 @@ builder.Services.AddCors(options =>
     });
 });
 
+// Abuse throttling. Values are deliberately hardcoded (small self-hosted app); the only
+// knob is the RateLimiting:Enabled kill-switch checked at UseRateLimiter below. Keys are
+// the direct peer IP on purpose: only X-Forwarded-Proto is trusted from proxies (see the
+// ForwardedHeaders comment), so X-Forwarded-For must not drive partitioning - behind a
+// reverse proxy all clients share the proxy's bucket until KnownProxies is pinned.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    options.GlobalLimiter = System.Threading.RateLimiting.PartitionedRateLimiter.Create<HttpContext, string>(ctx =>
+        ctx.Request.Path.StartsWithSegments("/healthz")
+            // The compose healthcheck polls this endpoint; it must never be throttled.
+            ? System.Threading.RateLimiting.RateLimitPartition.GetNoLimiter("healthz")
+            : System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+                ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 100,
+                    Window = TimeSpan.FromMinutes(1),
+                    QueueLimit = 0
+                }));
+
+    // Credential stuffing / junk-account / token-minting surface: login, register,
+    // guest, refresh.
+    options.AddPolicy("auth", ctx =>
+        System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(
+            ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            _ => new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            }));
+
+    options.OnRejected = (ctx, _) =>
+    {
+        ctx.HttpContext.Response.Headers.RetryAfter = "60";
+        return ValueTask.CompletedTask;
+    };
+});
+
 // Behind a TLS-terminating reverse proxy (the eventual VPS setup), the app sees plain
 // HTTP; honoring X-Forwarded-Proto keeps Request.IsHttps - and everything derived from
 // it, like the refresh cookie's Secure/SameSite attributes - correct. The proxy address
@@ -158,6 +202,7 @@ builder.Services.AddScoped<IStateGuidelineCatalog, StateGuidelineCatalog>();
 builder.Services.AddScoped<IParentProfileService, ParentProfileService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<AdminSeeder>();
+builder.Services.AddHostedService<RefreshTokenCleanupService>();
 
 var app = builder.Build();
 
@@ -238,6 +283,13 @@ app.UseForwardedHeaders();
 app.UseHttpsRedirection();
 
 app.UseCors("Web");
+
+// After UseCors so a 429 still carries CORS headers (otherwise the SPA sees an opaque
+// CORS failure instead of the status). Enabled is a kill-switch for tests/operators.
+if (builder.Configuration.GetValue("RateLimiting:Enabled", true))
+{
+    app.UseRateLimiter();
+}
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/FairShare.Api/Services/RefreshTokenCleanupService.cs
+++ b/src/FairShare.Api/Services/RefreshTokenCleanupService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Services;
+
+// Refresh tokens are single-use (rotated) and guest sign-ins mint a row per click, so
+// the table only shrinks if someone deletes the stale rows. Recently revoked tokens are
+// kept for a retention window: a revoked-but-unexpired token showing up again is the
+// replay signal, and deleting it too early would make a replay look like a random miss.
+public sealed class RefreshTokenCleanupService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<RefreshTokenCleanupService> logger) : BackgroundService
+{
+    private static readonly TimeSpan StartDelay = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(6);
+    private static readonly TimeSpan RevokedRetention = TimeSpan.FromDays(7);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(StartDelay, stoppingToken);
+
+            using PeriodicTimer timer = new(Interval);
+
+            do
+            {
+                try
+                {
+                    using IServiceScope scope = scopeFactory.CreateScope();
+                    FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+                    int deleted = await DeleteStaleAsync(db, DateTime.UtcNow, stoppingToken);
+
+                    if (deleted > 0)
+                    {
+                        logger.LogInformation("Refresh token cleanup removed {Count} stale rows.", deleted);
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogError(ex, "Refresh token cleanup pass failed; will retry next interval.");
+                }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException)
+        {
+            // Host shutdown.
+        }
+    }
+
+    public static async Task<int> DeleteStaleAsync(FairShareDbContext db, DateTime nowUtc, CancellationToken ct)
+    {
+        // Precomputed: EF cannot translate DateTime arithmetic to SQL.
+        DateTime revokedCutoff = nowUtc - RevokedRetention;
+
+        return await db.RefreshTokens
+            .Where(t => t.ExpiresUtc < nowUtc || (t.RevokedUtc != null && t.RevokedUtc < revokedCutoff))
+            .ExecuteDeleteAsync(ct);
+    }
+}

--- a/src/FairShare.Contracts/Admin/AdminContracts.cs
+++ b/src/FairShare.Contracts/Admin/AdminContracts.cs
@@ -29,6 +29,15 @@ public class CreateUserRequest
     public string Role { get; set; } = "User";
 }
 
+public class AdminResetPasswordRequest
+{
+    [Required, MinLength(8)]
+    public string NewPassword { get; set; } = string.Empty;
+
+    [Required, Compare(nameof(NewPassword), ErrorMessage = "Passwords do not match.")]
+    public string ConfirmNewPassword { get; set; } = string.Empty;
+}
+
 public class EditUserRequest
 {
     public Guid Id { get; set; }

--- a/src/FairShare.Contracts/Auth/AuthContracts.cs
+++ b/src/FairShare.Contracts/Auth/AuthContracts.cs
@@ -29,3 +29,20 @@ public class AuthTokenResponse
     public string Role { get; set; } = string.Empty;
     public bool IsGuest { get; set; }
 }
+
+public class AuthConfigResponse
+{
+    public bool AllowSelfRegistration { get; set; }
+}
+
+public class ChangePasswordRequest
+{
+    [Required]
+    public string CurrentPassword { get; set; } = string.Empty;
+
+    [Required, MinLength(8)]
+    public string NewPassword { get; set; } = string.Empty;
+
+    [Required, Compare(nameof(NewPassword), ErrorMessage = "Passwords do not match.")]
+    public string ConfirmNewPassword { get; set; } = string.Empty;
+}

--- a/src/FairShare.Tests/Api/AdminPasswordResetTests.cs
+++ b/src/FairShare.Tests/Api/AdminPasswordResetTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using FairShare.Contracts.Admin;
+using FairShare.Contracts.Auth;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class AdminPasswordResetTests : IClassFixture<FairShareApiFactory>
+{
+    private const string AdminPassword = "Adm!n-Test-12345";
+
+    private readonly HttpClient _client;
+
+    public AdminPasswordResetTests(FairShareApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            HandleCookies = false
+        });
+    }
+
+    [Fact]
+    public async Task ResetPassword_ChangesPasswordAndRevokesSessions()
+    {
+        string adminToken = await LoginTokenAsync("admin", AdminPassword);
+        Guid userId = await CreateUserAsync(adminToken, "carol", "Password-1");
+
+        // A live session for carol that the reset must kill.
+        HttpResponseMessage carolLogin = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = "carol",
+            Password = "Password-1"
+        });
+        Assert.Equal(HttpStatusCode.OK, carolLogin.StatusCode);
+        string carolCookie = ExtractRefreshCookie(carolLogin);
+
+        HttpResponseMessage resetResponse = await SendResetAsync(adminToken, userId, "Password-2");
+        Assert.Equal(HttpStatusCode.NoContent, resetResponse.StatusCode);
+
+        // Pre-reset refresh cookie is dead.
+        using HttpRequestMessage refresh = new(HttpMethod.Post, "api/v1/auth/refresh");
+        refresh.Headers.Add("Cookie", carolCookie);
+        HttpResponseMessage refreshResponse = await _client.SendAsync(refresh);
+        Assert.Equal(HttpStatusCode.Unauthorized, refreshResponse.StatusCode);
+
+        // Only the new password logs in.
+        HttpResponseMessage oldLogin = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest { UserName = "carol", Password = "Password-1" });
+        Assert.Equal(HttpStatusCode.Unauthorized, oldLogin.StatusCode);
+
+        HttpResponseMessage newLogin = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest { UserName = "carol", Password = "Password-2" });
+        Assert.Equal(HttpStatusCode.OK, newLogin.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResetPassword_AsNonAdmin_ReturnsForbidden()
+    {
+        string adminToken = await LoginTokenAsync("admin", AdminPassword);
+        Guid userId = await CreateUserAsync(adminToken, "dave", "Password-1");
+        string daveToken = await LoginTokenAsync("dave", "Password-1");
+
+        HttpResponseMessage response = await SendResetAsync(daveToken, userId, "Password-2");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ForUnknownUser_ReturnsNotFound()
+    {
+        string adminToken = await LoginTokenAsync("admin", AdminPassword);
+
+        HttpResponseMessage response = await SendResetAsync(adminToken, Guid.NewGuid(), "Password-2");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task<string> LoginTokenAsync(string userName, string password)
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = userName,
+            Password = password
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        AuthTokenResponse tokens = (await response.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+        return tokens.AccessToken;
+    }
+
+    private async Task<Guid> CreateUserAsync(string adminToken, string userName, string password)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "api/v1/admin/users")
+        {
+            Content = JsonContent.Create(new CreateUserRequest
+            {
+                UserName = userName,
+                Password = password,
+                ConfirmPassword = password,
+                Role = "User"
+            })
+        };
+        request.Headers.Add("Authorization", $"Bearer {adminToken}");
+
+        HttpResponseMessage response = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return body.RootElement.GetProperty("id").GetGuid();
+    }
+
+    private async Task<HttpResponseMessage> SendResetAsync(string accessToken, Guid userId, string newPassword)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, $"api/v1/admin/users/{userId}/reset-password")
+        {
+            Content = JsonContent.Create(new AdminResetPasswordRequest
+            {
+                NewPassword = newPassword,
+                ConfirmNewPassword = newPassword
+            })
+        };
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+
+        return await _client.SendAsync(request);
+    }
+
+    private static string ExtractRefreshCookie(HttpResponseMessage response)
+    {
+        Assert.True(response.Headers.TryGetValues("Set-Cookie", out var cookies));
+        string cookie = Assert.Single(cookies!, c => c.StartsWith("fairshare_refresh=", StringComparison.Ordinal));
+        return cookie.Split(';')[0];
+    }
+}

--- a/src/FairShare.Tests/Api/ChangePasswordTests.cs
+++ b/src/FairShare.Tests/Api/ChangePasswordTests.cs
@@ -1,0 +1,174 @@
+using FairShare.Contracts.Admin;
+using FairShare.Contracts.Auth;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class ChangePasswordTests : IClassFixture<FairShareApiFactory>
+{
+    private const string AdminPassword = "Adm!n-Test-12345";
+
+    // No automatic cookie handling: these tests juggle refresh cookies from several
+    // "sessions" of the same user, which a shared cookie container would silently merge.
+    private readonly HttpClient _client;
+
+    public ChangePasswordTests(FairShareApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            HandleCookies = false
+        });
+    }
+
+    [Fact]
+    public async Task ChangePassword_RevokesOtherSessions_AndKeepsCurrentOneAlive()
+    {
+        await CreateUserAsync("alice", "Password-1");
+
+        // Two independent sessions for alice.
+        (AuthTokenResponse _, string otherSessionCookie) = await LoginAsync("alice", "Password-1");
+        (AuthTokenResponse currentTokens, string _) = await LoginAsync("alice", "Password-1");
+
+        HttpResponseMessage changeResponse = await SendChangePasswordAsync(
+            currentTokens.AccessToken, "Password-1", "Password-2");
+
+        Assert.Equal(HttpStatusCode.OK, changeResponse.StatusCode);
+
+        AuthTokenResponse? newTokens = await changeResponse.Content.ReadFromJsonAsync<AuthTokenResponse>();
+        Assert.NotNull(newTokens);
+        Assert.False(string.IsNullOrWhiteSpace(newTokens!.AccessToken));
+
+        // The other session's refresh cookie must be dead...
+        Assert.Equal(HttpStatusCode.Unauthorized, await RefreshWithCookieAsync(otherSessionCookie));
+
+        // ...while the cookie issued by the change-password response still works.
+        string newCookie = ExtractRefreshCookie(changeResponse);
+        Assert.Equal(HttpStatusCode.OK, await RefreshWithCookieAsync(newCookie));
+
+        // And only the new password logs in.
+        Assert.Equal(HttpStatusCode.Unauthorized, await TryLoginAsync("alice", "Password-1"));
+        Assert.Equal(HttpStatusCode.OK, await TryLoginAsync("alice", "Password-2"));
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWrongCurrentPassword_ReturnsValidationProblem()
+    {
+        await CreateUserAsync("bob", "Password-1");
+        (AuthTokenResponse tokens, string _) = await LoginAsync("bob", "Password-1");
+
+        HttpResponseMessage response = await SendChangePasswordAsync(
+            tokens.AccessToken, "definitely-wrong-1", "Password-2");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("PasswordMismatch", body);
+
+        // The password did not change.
+        Assert.Equal(HttpStatusCode.OK, await TryLoginAsync("bob", "Password-1"));
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithGuestToken_ReturnsForbidden()
+    {
+        HttpResponseMessage guestResponse = await _client.PostAsync("api/v1/auth/guest", content: null);
+        AuthTokenResponse guestTokens = (await guestResponse.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+
+        HttpResponseMessage response = await SendChangePasswordAsync(
+            guestTokens.AccessToken, "irrelevant-1", "Password-2");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithoutToken_ReturnsUnauthorized()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/change-password", new ChangePasswordRequest
+        {
+            CurrentPassword = "irrelevant-1",
+            NewPassword = "Password-2",
+            ConfirmNewPassword = "Password-2"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private async Task CreateUserAsync(string userName, string password)
+    {
+        (AuthTokenResponse adminTokens, string _) = await LoginAsync("admin", AdminPassword);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "api/v1/admin/users")
+        {
+            Content = JsonContent.Create(new CreateUserRequest
+            {
+                UserName = userName,
+                Password = password,
+                ConfirmPassword = password,
+                Role = "User"
+            })
+        };
+        request.Headers.Add("Authorization", $"Bearer {adminTokens.AccessToken}");
+
+        HttpResponseMessage response = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    private async Task<(AuthTokenResponse Tokens, string RefreshCookie)> LoginAsync(string userName, string password)
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = userName,
+            Password = password
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        AuthTokenResponse tokens = (await response.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+        return (tokens, ExtractRefreshCookie(response));
+    }
+
+    private async Task<HttpStatusCode> TryLoginAsync(string userName, string password)
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = userName,
+            Password = password
+        });
+
+        return response.StatusCode;
+    }
+
+    private async Task<HttpResponseMessage> SendChangePasswordAsync(string accessToken, string currentPassword, string newPassword)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "api/v1/auth/change-password")
+        {
+            Content = JsonContent.Create(new ChangePasswordRequest
+            {
+                CurrentPassword = currentPassword,
+                NewPassword = newPassword,
+                ConfirmNewPassword = newPassword
+            })
+        };
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<HttpStatusCode> RefreshWithCookieAsync(string refreshCookie)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, "api/v1/auth/refresh");
+        request.Headers.Add("Cookie", refreshCookie);
+
+        HttpResponseMessage response = await _client.SendAsync(request);
+        return response.StatusCode;
+    }
+
+    private static string ExtractRefreshCookie(HttpResponseMessage response)
+    {
+        Assert.True(response.Headers.TryGetValues("Set-Cookie", out var cookies));
+        string cookie = Assert.Single(cookies!, c => c.StartsWith("fairshare_refresh=", StringComparison.Ordinal));
+        return cookie.Split(';')[0];
+    }
+}

--- a/src/FairShare.Tests/Api/FairShareApiFactory.cs
+++ b/src/FairShare.Tests/Api/FairShareApiFactory.cs
@@ -28,9 +28,14 @@ public class FairShareApiFactory : WebApplicationFactory<Program>
         SetEnvVar("AdminSeed__Password", "Adm!n-Test-12345");
         SetEnvVar("AdminSeed__LogGeneratedPassword", "false");
         SetEnvVar("Jwt__SigningKey", "test-signing-key-not-for-production-use-only-32b");
+        // Functional tests fire requests far faster than the per-IP budgets allow; the
+        // limiter has its own dedicated test class that switches this back on.
+        SetEnvVar("RateLimiting__Enabled", "false");
     }
 
-    private void SetEnvVar(string name, string value)
+    // Protected so factory subclasses can layer extra config (same precedence rules) on
+    // top of base.ConfigureWebHost - later writes win, and Dispose restores the original.
+    protected void SetEnvVar(string name, string value)
     {
         // Remember whatever was there before so Dispose can put it back - these are
         // process-wide and must not leak into tests outside this fixture's lifetime.

--- a/src/FairShare.Tests/Api/ParentsEndpointsTests.cs
+++ b/src/FairShare.Tests/Api/ParentsEndpointsTests.cs
@@ -1,3 +1,4 @@
+using FairShare.Contracts.Admin;
 using FairShare.Contracts.Auth;
 using FairShare.Contracts.Parents;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -148,17 +149,32 @@ public class ParentsEndpointsTests : IClassFixture<FairShareApiFactory>
         Assert.NotEqual(keep.Id, toRename.Id);
     }
 
+    // Self-registration is disabled by default, so second users are provisioned the way
+    // an operator would: created by the admin, then logged in.
     private async Task<string> RegisterUserAsync(string userName)
     {
-        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/register", new RegisterRequest
+        string adminToken = await LoginAsAdminAsync();
+
+        HttpResponseMessage createResponse = await SendAuthorizedAsync(HttpMethod.Post, "api/v1/admin/users", adminToken,
+            new CreateUserRequest
+            {
+                UserName = userName,
+                Password = "Upsert-Test-12345!",
+                ConfirmPassword = "Upsert-Test-12345!",
+                Role = "User"
+            });
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        HttpResponseMessage loginResponse = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
         {
             UserName = userName,
             Password = "Upsert-Test-12345!"
         });
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
 
-        AuthTokenResponse? tokens = await response.Content.ReadFromJsonAsync<AuthTokenResponse>();
+        AuthTokenResponse? tokens = await loginResponse.Content.ReadFromJsonAsync<AuthTokenResponse>();
         Assert.NotNull(tokens);
         Assert.False(string.IsNullOrWhiteSpace(tokens!.AccessToken));
         return tokens.AccessToken;

--- a/src/FairShare.Tests/Api/RateLimitingTests.cs
+++ b/src/FairShare.Tests/Api/RateLimitingTests.cs
@@ -1,0 +1,57 @@
+using FairShare.Contracts.Auth;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace FairShare.Tests.Api;
+
+public class RateLimitEnabledApiFactory : FairShareApiFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        SetEnvVar("RateLimiting__Enabled", "true");
+    }
+}
+
+[Collection("Api")]
+public class RateLimitingTests : IClassFixture<RateLimitEnabledApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public RateLimitingTests(RateLimitEnabledApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+
+    [Fact]
+    public async Task AuthEndpoint_Burst_GetsThrottledWith429AndRetryAfter()
+    {
+        // A nonexistent username so Identity lockout state is never touched; the request
+        // still counts against the "auth" policy. TestServer reports no RemoteIpAddress,
+        // so every request lands in the same "unknown" partition. 21 requests guarantee a
+        // rejection even if the burst straddles a fixed-window boundary (max 10+10 pass).
+        var statuses = new List<HttpResponseMessage>();
+
+        for (int i = 0; i < 21; i++)
+        {
+            statuses.Add(await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+            {
+                UserName = "no-such-user",
+                Password = "irrelevant-1"
+            }));
+        }
+
+        HttpResponseMessage? limited = statuses.FirstOrDefault(r => r.StatusCode == HttpStatusCode.TooManyRequests);
+
+        Assert.NotNull(limited);
+        Assert.True(limited!.Headers.TryGetValues("Retry-After", out var retryAfter));
+        Assert.Equal("60", Assert.Single(retryAfter!));
+
+        // The liveness probe must never be throttled (compose healthcheck).
+        HttpResponseMessage health = await _client.GetAsync("/healthz");
+        Assert.Equal(HttpStatusCode.OK, health.StatusCode);
+    }
+}

--- a/src/FairShare.Tests/Api/RefreshTokenCleanupTests.cs
+++ b/src/FairShare.Tests/Api/RefreshTokenCleanupTests.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using FairShare.Api.Models;
+using FairShare.Api.Persistence;
+using FairShare.Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class RefreshTokenCleanupTests : IClassFixture<FairShareApiFactory>
+{
+    private readonly FairShareApiFactory _factory;
+
+    public RefreshTokenCleanupTests(FairShareApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task DeleteStale_RemovesExpiredAndOldRevoked_KeepsActiveAndRecentlyRevoked()
+    {
+        DateTime now = DateTime.UtcNow;
+
+        using (IServiceScope scope = _factory.Services.CreateScope())
+        {
+            FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+            db.RefreshTokens.AddRange(
+                NewToken("cleanup-expired", expiresUtc: now.AddDays(-10)),
+                NewToken("cleanup-revoked-old", expiresUtc: now.AddDays(10), revokedUtc: now.AddDays(-8)),
+                NewToken("cleanup-active", expiresUtc: now.AddDays(10)),
+                NewToken("cleanup-revoked-recent", expiresUtc: now.AddDays(10), revokedUtc: now.AddDays(-1)));
+
+            await db.SaveChangesAsync();
+        }
+
+        using (IServiceScope scope = _factory.Services.CreateScope())
+        {
+            FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+            int deleted = await RefreshTokenCleanupService.DeleteStaleAsync(db, DateTime.UtcNow, CancellationToken.None);
+            Assert.Equal(2, deleted);
+
+            List<string> remaining = await db.RefreshTokens
+                .Where(t => t.TokenHash.StartsWith("cleanup-"))
+                .Select(t => t.TokenHash)
+                .ToListAsync();
+
+            Assert.Equal(["cleanup-active", "cleanup-revoked-recent"], remaining.OrderBy(h => h).ToList());
+        }
+    }
+
+    private static RefreshToken NewToken(string hash, DateTime expiresUtc, DateTime? revokedUtc = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = null,
+        IsGuest = true,
+        TokenHash = hash,
+        CreatedUtc = DateTime.UtcNow.AddDays(-30),
+        ExpiresUtc = expiresUtc,
+        RevokedUtc = revokedUtc
+    };
+}

--- a/src/FairShare.Tests/Api/RegistrationGateTests.cs
+++ b/src/FairShare.Tests/Api/RegistrationGateTests.cs
@@ -1,0 +1,97 @@
+using FairShare.Contracts.Auth;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class RegistrationGateTests : IClassFixture<FairShareApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public RegistrationGateTests(FairShareApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+
+    [Fact]
+    public async Task Register_ByDefault_ReturnsForbiddenProblem()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/register", new RegisterRequest
+        {
+            UserName = "newcomer",
+            Password = "Password-1"
+        });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Self-registration is disabled", body);
+    }
+
+    [Fact]
+    public async Task Config_ByDefault_ReportsSelfRegistrationDisabled()
+    {
+        AuthConfigResponse? config = await _client.GetFromJsonAsync<AuthConfigResponse>("api/v1/auth/config");
+
+        Assert.NotNull(config);
+        Assert.False(config!.AllowSelfRegistration);
+    }
+}
+
+public class RegistrationEnabledApiFactory : FairShareApiFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        SetEnvVar("Auth__AllowSelfRegistration", "true");
+    }
+}
+
+[Collection("Api")]
+public class RegistrationEnabledTests : IClassFixture<RegistrationEnabledApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public RegistrationEnabledTests(RegistrationEnabledApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+
+    [Fact]
+    public async Task Register_WhenEnabled_IssuesTokensAndRefreshCookie()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/register", new RegisterRequest
+        {
+            UserName = "self-registered",
+            Password = "Password-1"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        AuthTokenResponse? tokens = await response.Content.ReadFromJsonAsync<AuthTokenResponse>();
+
+        Assert.NotNull(tokens);
+        Assert.Equal("self-registered", tokens!.UserName);
+        Assert.False(tokens.IsGuest);
+        Assert.False(string.IsNullOrWhiteSpace(tokens.AccessToken));
+
+        Assert.True(response.Headers.TryGetValues("Set-Cookie", out var cookies));
+        Assert.Single(cookies!, c => c.StartsWith("fairshare_refresh=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Config_WhenEnabled_ReportsSelfRegistrationEnabled()
+    {
+        AuthConfigResponse? config = await _client.GetFromJsonAsync<AuthConfigResponse>("api/v1/auth/config");
+
+        Assert.NotNull(config);
+        Assert.True(config!.AllowSelfRegistration);
+    }
+}

--- a/src/FairShare.Web/Auth/AuthApiClient.cs
+++ b/src/FairShare.Web/Auth/AuthApiClient.cs
@@ -42,7 +42,11 @@ public class AuthApiClient(HttpClient http, ITokenStore tokenStore, JwtAuthentic
                 return config;
             }
         }
-        catch (Exception ex) when (ex is HttpRequestException or JsonException)
+        // OperationCanceledException covers WASM fetch timeouts (TaskCanceledException),
+        // NotSupportedException covers non-JSON bodies (e.g. a proxy error page). Any of
+        // these escaping would fault the cached task and wedge the auth pages until a
+        // full reload, so all realistic failures collapse to the fail-closed default.
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or OperationCanceledException or NotSupportedException)
         {
         }
 

--- a/src/FairShare.Web/Auth/AuthApiClient.cs
+++ b/src/FairShare.Web/Auth/AuthApiClient.cs
@@ -13,16 +13,23 @@ public class AuthApiClient(HttpClient http, ITokenStore tokenStore, JwtAuthentic
     private readonly HttpClient _http = http;
     private readonly ITokenStore _tokenStore = tokenStore;
     private readonly JwtAuthenticationStateProvider _authStateProvider = authStateProvider;
+    private readonly object _configLock = new();
     private Task<AuthConfigResponse>? _configTask;
 
     /// <summary>
     /// Server auth capabilities (e.g. whether self-registration is open). Cached for the
-    /// app's lifetime; concurrent callers share one request. Fails closed to "registration
-    /// disabled" when the API is unreachable - the server enforces the flag regardless, so
-    /// a wrongly hidden link is the safe failure - and drops the cache so a later page
-    /// visit retries.
+    /// app's lifetime; concurrent callers share one request (the lock makes the
+    /// check-and-assign atomic). Fails closed to "registration disabled" when the API is
+    /// unreachable - the server enforces the flag regardless, so a wrongly hidden link is
+    /// the safe failure - and drops the cache so a later page visit retries.
     /// </summary>
-    public Task<AuthConfigResponse> GetAuthConfigAsync() => _configTask ??= FetchAuthConfigAsync();
+    public Task<AuthConfigResponse> GetAuthConfigAsync()
+    {
+        lock (_configLock)
+        {
+            return _configTask ??= FetchAuthConfigAsync();
+        }
+    }
 
     private async Task<AuthConfigResponse> FetchAuthConfigAsync()
     {
@@ -39,7 +46,11 @@ public class AuthApiClient(HttpClient http, ITokenStore tokenStore, JwtAuthentic
         {
         }
 
-        _configTask = null;
+        lock (_configLock)
+        {
+            _configTask = null;
+        }
+
         return new AuthConfigResponse();
     }
 
@@ -131,8 +142,9 @@ public class AuthApiClient(HttpClient http, ITokenStore tokenStore, JwtAuthentic
 
     // The API reports failures as RFC 7807 problem details; surface the first field error
     // (e.g. "Username 'x' is already taken.") so the user sees something actionable
-    // instead of a bare status code.
-    private static async Task<string?> TryReadFirstProblemErrorAsync(HttpResponseMessage response)
+    // instead of a bare status code. Internal so pages issuing raw HttpClient calls
+    // (e.g. the admin reset-password form) can surface the same details.
+    internal static async Task<string?> TryReadFirstProblemErrorAsync(HttpResponseMessage response)
     {
         try
         {

--- a/src/FairShare.Web/Auth/AuthApiClient.cs
+++ b/src/FairShare.Web/Auth/AuthApiClient.cs
@@ -13,6 +13,45 @@ public class AuthApiClient(HttpClient http, ITokenStore tokenStore, JwtAuthentic
     private readonly HttpClient _http = http;
     private readonly ITokenStore _tokenStore = tokenStore;
     private readonly JwtAuthenticationStateProvider _authStateProvider = authStateProvider;
+    private Task<AuthConfigResponse>? _configTask;
+
+    /// <summary>
+    /// Server auth capabilities (e.g. whether self-registration is open). Cached for the
+    /// app's lifetime; concurrent callers share one request. Fails closed to "registration
+    /// disabled" when the API is unreachable - the server enforces the flag regardless, so
+    /// a wrongly hidden link is the safe failure - and drops the cache so a later page
+    /// visit retries.
+    /// </summary>
+    public Task<AuthConfigResponse> GetAuthConfigAsync() => _configTask ??= FetchAuthConfigAsync();
+
+    private async Task<AuthConfigResponse> FetchAuthConfigAsync()
+    {
+        try
+        {
+            AuthConfigResponse? config = await _http.GetFromJsonAsync<AuthConfigResponse>("api/v1/auth/config");
+
+            if (config is not null)
+            {
+                return config;
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException)
+        {
+        }
+
+        _configTask = null;
+        return new AuthConfigResponse();
+    }
+
+    public Task<AuthResult> ChangePasswordAsync(string currentPassword, string newPassword, string confirmNewPassword) =>
+        SendAuthRequestAsync(
+            "api/v1/auth/change-password",
+            new ChangePasswordRequest
+            {
+                CurrentPassword = currentPassword,
+                NewPassword = newPassword,
+                ConfirmNewPassword = confirmNewPassword
+            });
 
     public Task<AuthResult> LoginAsync(string userName, string password) =>
         SendAuthRequestAsync(

--- a/src/FairShare.Web/Auth/AuthTokenHandler.cs
+++ b/src/FairShare.Web/Auth/AuthTokenHandler.cs
@@ -42,10 +42,14 @@ public class AuthTokenHandler(ITokenStore tokenStore, JwtAuthenticationStateProv
             return response;
         }
 
-        // A 401 from login/register/guest is a real auth failure (bad credentials, disabled
-        // user, etc.), not an expired-token situation - don't let it trigger a refresh+retry,
-        // which could otherwise turn a failed login into an "authenticated" state.
-        if (uri.AbsolutePath.Contains("/api/v1/auth/", StringComparison.OrdinalIgnoreCase))
+        // A 401 from the anonymous auth endpoints (login/register/guest/refresh) is a real
+        // auth failure (bad credentials, disabled user, etc.), not an expired-token
+        // situation - don't let it trigger a refresh+retry, which could otherwise turn a
+        // failed login into an "authenticated" state. change-password is the exception:
+        // it's the one *authenticated* endpoint under the auth prefix, so an expired access
+        // token there should get the normal silent refresh+retry like any other API call.
+        if (uri.AbsolutePath.Contains("/api/v1/auth/", StringComparison.OrdinalIgnoreCase)
+            && !uri.AbsolutePath.EndsWith("/change-password", StringComparison.OrdinalIgnoreCase))
         {
             return response;
         }

--- a/src/FairShare.Web/Dockerfile
+++ b/src/FairShare.Web/Dockerfile
@@ -18,10 +18,13 @@ FROM nginx:alpine AS runtime
 
 COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
 COPY src/FairShare.Web/nginx.conf /etc/nginx/conf.d/default.conf
+# .inc extension keeps it out of nginx's conf.d/*.conf auto-include; nginx.conf includes it.
+COPY src/FairShare.Web/fairshare-security-headers.inc /etc/nginx/conf.d/fairshare-security-headers.inc
 # nginx's stock entrypoint runs every script in /docker-entrypoint.d before serving.
 COPY src/FairShare.Web/docker-entrypoint.d/40-fairshare-appsettings.sh /docker-entrypoint.d/40-fairshare-appsettings.sh
+COPY src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh /docker-entrypoint.d/50-fairshare-csp.sh
 
 RUN rm -f /usr/share/nginx/html/appsettings.Development.json \
- && chmod +x /docker-entrypoint.d/40-fairshare-appsettings.sh
+ && chmod +x /docker-entrypoint.d/40-fairshare-appsettings.sh /docker-entrypoint.d/50-fairshare-csp.sh
 
 EXPOSE 80

--- a/src/FairShare.Web/Layout/NavMenu.razor
+++ b/src/FairShare.Web/Layout/NavMenu.razor
@@ -17,6 +17,9 @@
                             <li class="nav-item">
                                 <NavLink class="nav-link" href="profiles">Parents</NavLink>
                             </li>
+                            <li class="nav-item">
+                                <NavLink class="nav-link" href="account/change-password">Account</NavLink>
+                            </li>
                         }
                         @if (context.User.IsInRole("Admin"))
                         {

--- a/src/FairShare.Web/Pages/Admin/EditUser.razor
+++ b/src/FairShare.Web/Pages/Admin/EditUser.razor
@@ -137,7 +137,8 @@
         }
         else
         {
-            resetError = "Failed to reset password. Check that it meets the requirements.";
+            resetError = await FairShare.Web.Auth.AuthApiClient.TryReadFirstProblemErrorAsync(response)
+                ?? $"Failed to reset password ({(int)response.StatusCode}).";
         }
     }
 

--- a/src/FairShare.Web/Pages/Admin/EditUser.razor
+++ b/src/FairShare.Web/Pages/Admin/EditUser.razor
@@ -57,6 +57,38 @@
                         <button type="button" class="btn btn-outline-secondary" @onclick="Cancel">Cancel</button>
                     </div>
                 </EditForm>
+
+                <hr class="my-4" />
+
+                <h5>Reset password</h5>
+                <p class="text-muted"><small>Resetting signs the user out of all sessions. To change your own password, use the Account page.</small></p>
+
+                @if (!string.IsNullOrEmpty(resetSuccess))
+                {
+                    <div class="alert alert-success py-2">@resetSuccess</div>
+                }
+                @if (!string.IsNullOrEmpty(resetError))
+                {
+                    <div class="alert alert-danger py-2">@resetError</div>
+                }
+
+                <EditForm Model="resetModel" OnValidSubmit="HandleResetPassword" FormName="resetPasswordForm">
+                    <DataAnnotationsValidator />
+
+                    <div class="mb-3">
+                        <label for="newPassword" class="form-label">New Password</label>
+                        <InputText id="newPassword" type="password" @bind-Value="resetModel.NewPassword" class="form-control" />
+                        <ValidationMessage For="() => resetModel.NewPassword" class="text-danger" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="confirmNewPassword" class="form-label">Confirm New Password</label>
+                        <InputText id="confirmNewPassword" type="password" @bind-Value="resetModel.ConfirmNewPassword" class="form-control" />
+                        <ValidationMessage For="() => resetModel.ConfirmNewPassword" class="text-danger" />
+                    </div>
+
+                    <button type="submit" class="btn btn-outline-danger">Reset Password</button>
+                </EditForm>
             </div>
         </div>
     }
@@ -66,6 +98,9 @@
     [Parameter] public Guid Id { get; set; }
     private EditUserRequest? model;
     private List<string> errors = new();
+    private AdminResetPasswordRequest resetModel = new();
+    private string? resetError;
+    private string? resetSuccess;
 
     protected override async Task OnInitializedAsync()
     {
@@ -85,6 +120,24 @@
         else
         {
             errors.Add("Failed to update user.");
+        }
+    }
+
+    private async Task HandleResetPassword()
+    {
+        resetError = null;
+        resetSuccess = null;
+
+        var response = await Http.PostAsJsonAsync($"api/v1/admin/users/{Id}/reset-password", resetModel);
+
+        if (response.IsSuccessStatusCode)
+        {
+            resetModel = new AdminResetPasswordRequest();
+            resetSuccess = "Password reset. The user has been signed out of all sessions.";
+        }
+        else
+        {
+            resetError = "Failed to reset password. Check that it meets the requirements.";
         }
     }
 

--- a/src/FairShare.Web/Pages/Admin/EditUser.razor
+++ b/src/FairShare.Web/Pages/Admin/EditUser.razor
@@ -128,7 +128,7 @@
         resetError = null;
         resetSuccess = null;
 
-        var response = await Http.PostAsJsonAsync($"api/v1/admin/users/{Id}/reset-password", resetModel);
+        using HttpResponseMessage response = await Http.PostAsJsonAsync($"api/v1/admin/users/{Id}/reset-password", resetModel);
 
         if (response.IsSuccessStatusCode)
         {

--- a/src/FairShare.Web/Pages/ChangePassword.razor
+++ b/src/FairShare.Web/Pages/ChangePassword.razor
@@ -1,0 +1,82 @@
+@page "/account/change-password"
+@attribute [Authorize(Policy = "NotGuest")]
+@inject FairShare.Web.Auth.AuthApiClient AuthApi
+
+<PageTitle>FairShare - Change Password</PageTitle>
+
+<div class="container my-5" style="max-width: 420px;">
+    <h1 class="h4 mb-4 text-center">Change password</h1>
+
+    @if (!string.IsNullOrEmpty(_success))
+    {
+        <div class="alert alert-success py-2">@_success</div>
+    }
+
+    <EditForm Model="_model" OnValidSubmit="SubmitAsync">
+        <DataAnnotationsValidator />
+
+        <div class="mb-3">
+            <label class="form-label" for="currentPassword">Current Password</label>
+            <InputText id="currentPassword" type="password" class="form-control" @bind-Value="_model.CurrentPassword" />
+            <ValidationMessage For="() => _model.CurrentPassword" class="text-danger" />
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label" for="newPassword">New Password</label>
+            <InputText id="newPassword" type="password" class="form-control" @bind-Value="_model.NewPassword" />
+            <ValidationMessage For="() => _model.NewPassword" class="text-danger" />
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label" for="confirmNewPassword">Confirm New Password</label>
+            <InputText id="confirmNewPassword" type="password" class="form-control" @bind-Value="_model.ConfirmNewPassword" />
+            <ValidationMessage For="() => _model.ConfirmNewPassword" class="text-danger" />
+        </div>
+
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <div class="alert alert-danger py-2">@_error</div>
+        }
+
+        <button type="submit" class="btn btn-primary w-100" disabled="@_busy">Change Password</button>
+    </EditForm>
+</div>
+
+@code {
+    private ChangePasswordModel _model = new();
+    private string? _error;
+    private string? _success;
+    private bool _busy;
+
+    private async Task SubmitAsync()
+    {
+        _busy = true;
+        _error = null;
+        _success = null;
+
+        var result = await AuthApi.ChangePasswordAsync(_model.CurrentPassword, _model.NewPassword, _model.ConfirmNewPassword);
+
+        _busy = false;
+
+        if (!result.Success)
+        {
+            _error = result.Error;
+            return;
+        }
+
+        _model = new ChangePasswordModel();
+        _success = "Password changed. Other sessions have been signed out.";
+    }
+
+    private class ChangePasswordModel
+    {
+        [System.ComponentModel.DataAnnotations.Required]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        [System.ComponentModel.DataAnnotations.Required, System.ComponentModel.DataAnnotations.MinLength(8)]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [System.ComponentModel.DataAnnotations.Required, System.ComponentModel.DataAnnotations.Compare(nameof(NewPassword), ErrorMessage = "Passwords do not match.")]
+        public string ConfirmNewPassword { get; set; } = string.Empty;
+    }
+}

--- a/src/FairShare.Web/Pages/ChangePassword.razor
+++ b/src/FairShare.Web/Pages/ChangePassword.razor
@@ -54,18 +54,27 @@
         _error = null;
         _success = null;
 
-        var result = await AuthApi.ChangePasswordAsync(_model.CurrentPassword, _model.NewPassword, _model.ConfirmNewPassword);
-
-        _busy = false;
-
-        if (!result.Success)
+        try
         {
-            _error = result.Error;
-            return;
-        }
+            var result = await AuthApi.ChangePasswordAsync(_model.CurrentPassword, _model.NewPassword, _model.ConfirmNewPassword);
 
-        _model = new ChangePasswordModel();
-        _success = "Password changed. Other sessions have been signed out.";
+            if (!result.Success)
+            {
+                _error = result.Error;
+                return;
+            }
+
+            _model = new ChangePasswordModel();
+            _success = "Password changed. Other sessions have been signed out.";
+        }
+        catch (HttpRequestException)
+        {
+            _error = "Could not reach the server. Please try again.";
+        }
+        finally
+        {
+            _busy = false;
+        }
     }
 
     private class ChangePasswordModel

--- a/src/FairShare.Web/Pages/Login.razor
+++ b/src/FairShare.Web/Pages/Login.razor
@@ -31,7 +31,14 @@
     </EditForm>
 
     <div class="d-flex justify-content-between mt-3">
-        <a href="/register">Create an account</a>
+        @if (_allowSelfRegistration)
+        {
+            <a href="/register">Create an account</a>
+        }
+        else
+        {
+            <span></span>
+        }
         <button class="btn btn-link p-0" @onclick="ContinueAsGuestAsync" disabled="@_busy">Continue as Guest</button>
     </div>
 </div>
@@ -40,9 +47,16 @@
     private readonly LoginModel _model = new();
     private string? _error;
     private bool _busy;
+    private bool _allowSelfRegistration;
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var config = await AuthApi.GetAuthConfigAsync();
+        _allowSelfRegistration = config.AllowSelfRegistration;
+    }
 
     private async Task LoginAsync()
     {

--- a/src/FairShare.Web/Pages/Register.razor
+++ b/src/FairShare.Web/Pages/Register.razor
@@ -8,6 +8,22 @@
 <div class="container my-5" style="max-width: 420px;">
     <h1 class="h4 mb-4 text-center">Create an account</h1>
 
+    @if (!_loaded)
+    {
+        <p class="text-center text-muted">Loading...</p>
+    }
+    else if (!_allowSelfRegistration)
+    {
+        <div class="card">
+            <div class="card-body text-center">
+                <p class="mb-2">Self-registration is disabled on this server.</p>
+                <p class="text-muted mb-3"><small>Contact the administrator for an account.</small></p>
+                <a href="/login" class="btn btn-primary">Back to sign in</a>
+            </div>
+        </div>
+    }
+    else
+    {
     <EditForm Model="_model" OnValidSubmit="RegisterAsync">
         <DataAnnotationsValidator />
         <ValidationSummary />
@@ -38,12 +54,22 @@
     <div class="text-center mt-3">
         <a href="/login">Already have an account? Sign in</a>
     </div>
+    }
 </div>
 
 @code {
     private readonly RegisterModel _model = new();
     private string? _error;
     private bool _busy;
+    private bool _loaded;
+    private bool _allowSelfRegistration;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var config = await AuthApi.GetAuthConfigAsync();
+        _allowSelfRegistration = config.AllowSelfRegistration;
+        _loaded = true;
+    }
 
     private async Task RegisterAsync()
     {

--- a/src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh
+++ b/src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# The SPA and API run on different origins, so the CSP's connect-src must allow the
+# browser-visible API origin. Injected at container start (same pattern as
+# 40-fairshare-appsettings.sh) so the CSP tracks API_BASE_URL without an image rebuild.
+set -e
+
+HEADERS_FILE=/etc/nginx/conf.d/fairshare-security-headers.inc
+
+if [ -n "${API_BASE_URL:-}" ]; then
+    # Strip any trailing slash: CSP source expressions are origins, not URLs.
+    origin=$(printf '%s' "$API_BASE_URL" | sed 's:/*$::')
+    # Pipe delimiter because the origin contains '://'.
+    sed -i "s|connect-src 'self'|connect-src 'self' ${origin}|" "$HEADERS_FILE"
+    echo "FairShare.Web: CSP connect-src extended with $origin"
+else
+    echo "FairShare.Web: API_BASE_URL not set; CSP connect-src stays same-origin"
+fi

--- a/src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh
+++ b/src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh
@@ -7,11 +7,15 @@ set -e
 HEADERS_FILE=/etc/nginx/conf.d/fairshare-security-headers.inc
 
 if [ -n "${API_BASE_URL:-}" ]; then
-    # Strip any trailing slash: CSP source expressions are origins, not URLs.
-    origin=$(printf '%s' "$API_BASE_URL" | sed 's:/*$::')
-    # Pipe delimiter because the origin contains '://'.
-    sed -i "s|connect-src 'self'|connect-src 'self' ${origin}|" "$HEADERS_FILE"
-    echo "FairShare.Web: CSP connect-src extended with $origin"
+    # Reduce to an origin (scheme://host[:port]) - CSP source expressions are origins,
+    # not URLs, so any path/query on API_BASE_URL must be dropped.
+    origin=$(printf '%s' "$API_BASE_URL" | sed -E 's|^([A-Za-z][A-Za-z0-9+.-]*://[^/]+).*|\1|')
+    # Escape sed-replacement metacharacters so a hostile/odd value can't mangle the file.
+    escaped=$(printf '%s' "$origin" | sed 's/[&\\|]/\\&/g')
+    # Replace the whole connect-src clause (not just append after 'self') so re-running
+    # on container restart is idempotent and an old origin never lingers.
+    sed -i "s|connect-src [^;]*|connect-src 'self' ${escaped}|" "$HEADERS_FILE"
+    echo "FairShare.Web: CSP connect-src set to 'self' $origin"
 else
     echo "FairShare.Web: API_BASE_URL not set; CSP connect-src stays same-origin"
 fi

--- a/src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh
+++ b/src/FairShare.Web/docker-entrypoint.d/50-fairshare-csp.sh
@@ -8,8 +8,18 @@ HEADERS_FILE=/etc/nginx/conf.d/fairshare-security-headers.inc
 
 if [ -n "${API_BASE_URL:-}" ]; then
     # Reduce to an origin (scheme://host[:port]) - CSP source expressions are origins,
-    # not URLs, so any path/query on API_BASE_URL must be dropped.
-    origin=$(printf '%s' "$API_BASE_URL" | sed -E 's|^([A-Za-z][A-Za-z0-9+.-]*://[^/]+).*|\1|')
+    # not URLs, so any path/query/fragment must be dropped. POSIX parameter expansion
+    # only: no dependence on the sed flavor shipped in the base image.
+    case "$API_BASE_URL" in
+        *://*)
+            scheme=${API_BASE_URL%%://*}
+            rest=${API_BASE_URL#*://}
+            origin="${scheme}://${rest%%[/?#]*}"
+            ;;
+        *)
+            origin=${API_BASE_URL%%[/?#]*}
+            ;;
+    esac
     # Escape sed-replacement metacharacters so a hostile/odd value can't mangle the file.
     escaped=$(printf '%s' "$origin" | sed 's/[&\\|]/\\&/g')
     # Replace the whole connect-src clause (not just append after 'self') so re-running

--- a/src/FairShare.Web/fairshare-security-headers.inc
+++ b/src/FairShare.Web/fairshare-security-headers.inc
@@ -1,0 +1,15 @@
+# Security headers for every response. The .inc extension keeps this file out of
+# nginx's conf.d/*.conf auto-include glob; it is pulled in explicitly by nginx.conf -
+# at server level AND inside every location that has its own add_header, because
+# add_header in a nested location silently discards all inherited headers.
+#
+# CSP notes:
+# - 'wasm-unsafe-eval' is required by the .NET (Blazor) WASM runtime.
+# - style-src 'unsafe-inline' covers Blazor's and Bootstrap's inline style attributes.
+# - connect-src 'self' is rewritten at container start by 50-fairshare-csp.sh to also
+#   allow the cross-origin API (API_BASE_URL).
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header X-Frame-Options "DENY" always;

--- a/src/FairShare.Web/nginx.conf
+++ b/src/FairShare.Web/nginx.conf
@@ -1,5 +1,8 @@
 server {
+    # Both stacks: busybox wget (the compose healthcheck) resolves localhost to ::1
+    # first on current nginx:alpine images, and a bare "listen 80" is IPv4-only.
     listen 80;
+    listen [::]:80;
     server_name _;
 
     root /usr/share/nginx/html;
@@ -9,9 +12,15 @@ server {
     gzip_comp_level 5;
     gzip_types application/wasm application/javascript application/json application/octet-stream text/css text/javascript image/svg+xml;
 
+    # Security headers (CSP etc.). Re-included inside every location below that has
+    # its own add_header: nginx's add_header inheritance is all-or-nothing, so a
+    # location-level Cache-Control would otherwise silently drop these.
+    include /etc/nginx/conf.d/fairshare-security-headers.inc;
+
     # Fingerprinted Blazor framework assets never change under the same name.
     location /_framework/ {
         add_header Cache-Control "public, max-age=31536000, immutable";
+        include /etc/nginx/conf.d/fairshare-security-headers.inc;
         try_files $uri =404;
     }
 
@@ -19,10 +28,12 @@ server {
     # and API_BASE_URL changes take effect immediately.
     location = /index.html {
         add_header Cache-Control "no-cache";
+        include /etc/nginx/conf.d/fairshare-security-headers.inc;
     }
 
     location = /appsettings.json {
         add_header Cache-Control "no-cache";
+        include /etc/nginx/conf.d/fairshare-security-headers.inc;
     }
 
     # SPA fallback: client-side routes (/login, /States/AL/CS42, ...) are served the host page.

--- a/src/FairShare.Web/wwwroot/index.html
+++ b/src/FairShare.Web/wwwroot/index.html
@@ -10,15 +10,7 @@
     <link rel="stylesheet" href="css/site.css" />
     <link rel="stylesheet" href="app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <script>
-        (function () {
-            var stored = localStorage.getItem('fairshare-theme') || 'auto';
-            var resolved = stored === 'auto'
-                ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-                : stored;
-            document.documentElement.setAttribute('data-bs-theme', resolved);
-        })();
-    </script>
+    <script src="js/theme-init.js"></script>
 </head>
 
 <body>

--- a/src/FairShare.Web/wwwroot/js/theme-init.js
+++ b/src/FairShare.Web/wwwroot/js/theme-init.js
@@ -1,0 +1,10 @@
+// Loaded synchronously in <head> so the theme is applied before first paint (no
+// light-mode flash). Lives in its own file instead of an inline <script> so the
+// CSP can stay at script-src 'self' with no inline allowances.
+(function () {
+    var stored = localStorage.getItem('fairshare-theme') || 'auto';
+    var resolved = stored === 'auto'
+        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : stored;
+    document.documentElement.setAttribute('data-bs-theme', resolved);
+})();


### PR DESCRIPTION
## Summary

Hardens FairShare for public exposure, closing the gaps identified in the security review:

- **Rate limiting** — 100 req/min per IP globally, 10 req/min on `login`/`register`/`guest`/`refresh`; 429 + `Retry-After`; `/healthz` exempt; `RateLimiting:Enabled` kill-switch (default on)
- **Registration gate** — `Auth:AllowSelfRegistration` defaults to **false** (BREAKING); anonymous `GET /api/v1/auth/config` exposes the flag; SPA hides the register link and shows a disabled card
- **Password management** — self-service `POST /auth/change-password` (revokes all refresh tokens, re-issues for the current session) and admin `POST /admin/users/{id}/reset-password` (token-based reset, clears lockout, revokes sessions), with matching Blazor UI
- **Refresh-token cleanup** — background service purges expired rows and revoked rows older than 7 days, every 6 hours
- **nginx security headers + CSP** — full header set on every location (add_header inheritance handled); inline theme script extracted to `js/theme-init.js` so `script-src` stays `'self' 'wasm-unsafe-eval'`; entrypoint script injects the API origin into `connect-src` from `API_BASE_URL`
- **Admin bootstrap hardening** — `ADMIN_SEED_ENABLED` / `ADMIN_SEED_LOG_GENERATED_PASSWORD` now tunable; README guidance on treating a generated password as burned

## Breaking change

Self-registration is now disabled by default. Set `ALLOW_SELF_REGISTRATION=true` in `.env` (or `Auth__AllowSelfRegistration=true`) to restore the previous behavior.

## Testing

- 36/36 tests pass (13 new: registration gate/enabled, change-password session semantics, admin reset, rate limiting 429, cleanup retention)
- Docker smoke verified: headers + injected CSP on `/`, `/appsettings.json`, `/_framework/*`; register → 403; login burst → 429 while `/healthz` stays 200; live change-password/reset round-trip with session revocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)