### PR TITLE
docs: API reference, per-project READMEs, and root README corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ FairShare gives a quick, transparent estimate of who pays child support and how 
 
 ## What’s new in v8
 
+- **Public hardening (8.0.0)**: Per-IP rate limiting (strict budget on the auth endpoints), self-registration disabled by default (**breaking** — set `ALLOW_SELF_REGISTRATION=true` to restore sign-ups), self-service change-password and admin password reset (both revoke all of the user's sessions), automatic refresh-token cleanup, and CSP/security headers on the web container.
 - **Architecture Overhaul**: Split into a standalone Blazor WebAssembly SPA (`FairShare.Web`) and an independent REST API (`FairShare.Api`), replacing the previous hybrid server-hosted-WASM app.
 - **JWT Auth**: Cookie-based ASP.NET Identity replaced with JWT bearer auth (access + rotating refresh tokens), so the API is directly usable from curl/Postman/any CLI — not just the browser.
 - **Server-side Calculations**: Calculation logic moved behind `POST /api/v1/states/{state}/forms/{form}/calculations`, so results are consistent regardless of client.
@@ -49,11 +50,13 @@ FairShare gives a quick, transparent estimate of who pays child support and how 
 
 | Project | Type | Responsibility |
 |---|---|---|
-| `FairShare.Domain` | classlib | Pure calculation engine — calculators, state/form catalog. No EF/Identity/ASP.NET. |
-| `FairShare.Contracts` | classlib | Wire DTOs shared by the API and the Web app (auth, calculation, parents, admin). |
-| `FairShare.Api` | ASP.NET Core Web API | JWT auth, EF Core + SQLite persistence, all controllers. |
-| `FairShare.Web` | Blazor WebAssembly | Standalone SPA calling the API over HTTP/JSON with a JWT bearer token. |
-| `FairShare.Tests` | xUnit | Calculator unit tests + API integration tests (`WebApplicationFactory`). |
+| [`FairShare.Domain`](src/FairShare.Domain/README.md) | classlib | Pure calculation engine — calculators, state/form catalog. No EF/Identity/ASP.NET. |
+| [`FairShare.Contracts`](src/FairShare.Contracts/README.md) | classlib | Wire DTOs shared by the API and the Web app (auth, calculation, parents, admin). |
+| [`FairShare.Api`](src/FairShare.Api/README.md) | ASP.NET Core Web API | JWT auth, EF Core + SQLite persistence, all controllers. |
+| [`FairShare.Web`](src/FairShare.Web/README.md) | Blazor WebAssembly | Standalone SPA calling the API over HTTP/JSON with a JWT bearer token. |
+| [`FairShare.Tests`](src/FairShare.Tests/README.md) | xUnit | Calculator unit tests + API integration tests (`WebApplicationFactory`). |
+
+Each project has its own README with conventions and extension points; the full endpoint reference lives in [`docs/API.md`](docs/API.md).
 
 ---
 
@@ -80,7 +83,7 @@ docker compose up --build
 ```
 
 - Web app: http://localhost:5858
-- API + Swagger: http://localhost:5859 (`/swagger`, `/healthz`)
+- API: http://localhost:5859 (`/healthz`; Swagger is **Development-only** and not served by the Production compose build — use the bare `dotnet run` setup below to browse it)
 
 If `ADMIN_PASSWORD` was left empty, the generated admin password is printed once in `docker compose logs api`. The SQLite database (and pre-migration backups) persist in the named `fairshare-data` volume across restarts.
 
@@ -131,7 +134,7 @@ curl http://localhost:5080/api/v1/states \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-Swagger UI is available at `/swagger` in Development.
+Swagger UI is available at `/swagger` in Development. The full endpoint reference — auth flow, request/response bodies, error shapes, and rate-limit behavior — is in [`docs/API.md`](docs/API.md), and a ready-to-import Postman collection (chained auth, sample bodies, assertions) is at [`docs/FairShare.postman_collection.json`](docs/FairShare.postman_collection.json).
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,13 +18,13 @@ A typical non-browser client only needs the access token: log in, use the bearer
 ### Auth session flow
 
 ```
-POST /auth/login ─────► 200 { accessToken, ... } + Set-Cookie: fairshare_refresh
+POST /api/v1/auth/login ─────► 200 { accessToken, ... } + Set-Cookie: fairshare_refresh
         │
         ▼ (access token expires after 30 min)
-POST /auth/refresh (cookie) ─► 200 { new accessToken } + rotated cookie
+POST /api/v1/auth/refresh (cookie) ─► 200 { new accessToken } + rotated cookie
         │
         ▼
-POST /auth/logout (cookie) ──► 204, cookie consumed + cleared
+POST /api/v1/auth/logout (cookie) ──► 204, cookie consumed + cleared
 ```
 
 ## Conventions

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,195 @@
+# FairShare API Reference
+
+REST API for the FairShare child-support calculator. JSON everywhere, JWT bearer auth, versioned under `/api/v1`.
+
+All examples use the local dev URL (`http://localhost:5080`). Substitute your own deployment's API origin. Interactive Swagger UI is available at `/swagger` **in Development only** — it is deliberately disabled in Production builds.
+
+## Authentication model
+
+| Piece | Details |
+|---|---|
+| Access token | JWT (HMAC-SHA256), returned in auth response bodies. Send as `Authorization: Bearer <token>`. Lifetime: 30 min (`Jwt:AccessTokenMinutes`). |
+| Refresh token | Opaque value in an `HttpOnly` cookie (`fairshare_refresh`, `Path=/api/v1/auth`). **Single-use**: every call to `/auth/refresh` revokes the presented token and issues a new one. Replaying a consumed token returns 401. Lifetime: 30 days (`Jwt:RefreshTokenDays`). Stored server-side as a SHA-256 hash. |
+| Guest | `POST /auth/guest` issues a token with a `guest` claim — can run calculations and browse the catalog, cannot save data or manage anything. |
+| Roles | `User` (default), `Admin` (user management). Endpoints marked **Admin** require the Admin role; endpoints marked **NotGuest** reject guest tokens with 403. |
+
+A typical non-browser client only needs the access token: log in, use the bearer, log in again when it expires. The refresh cookie exists primarily for the SPA.
+
+### Auth session flow
+
+```
+POST /auth/login ─────► 200 { accessToken, ... } + Set-Cookie: fairshare_refresh
+        │
+        ▼ (access token expires after 30 min)
+POST /auth/refresh (cookie) ─► 200 { new accessToken } + rotated cookie
+        │
+        ▼
+POST /auth/logout (cookie) ──► 204, cookie consumed + cleared
+```
+
+## Conventions
+
+- **Errors** are RFC 7807 problem details (`application/problem+json`). Validation failures carry an `errors` object keyed by error code:
+  ```json
+  { "title": "One or more validation errors occurred.", "status": 400,
+    "errors": { "PasswordTooShort": ["Passwords must be at least 8 characters."] } }
+  ```
+- **Login failures are uniform**: wrong password, unknown user, disabled account, and lockout all return a bare `401` with no body — deliberately indistinguishable.
+- **Lockout**: 5 consecutive failed logins lock the account for ~5 minutes.
+- **Rate limits** (per client IP): 100 requests/min globally; **10 requests/min shared across** `login`, `register`, `guest`, and `refresh`. Exceeding either returns `429` with `Retry-After: 60`. `/healthz` is exempt.
+
+---
+
+## Auth — `/api/v1/auth`
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| GET | `/auth/config` | none | Server capabilities: `{ "allowSelfRegistration": bool }`. |
+| POST | `/auth/register` | none | Create an account. Returns **403** when self-registration is disabled (the default). |
+| POST | `/auth/login` | none | Exchange credentials for tokens. |
+| POST | `/auth/guest` | none | Issue a guest session (no body). |
+| POST | `/auth/refresh` | refresh cookie | Rotate the refresh token, get a new access token. |
+| POST | `/auth/logout` | refresh cookie | Revoke the presented refresh token, clear the cookie. 204. |
+| POST | `/auth/change-password` | Bearer, NotGuest | Change your own password. Revokes **all** of your refresh tokens, then returns fresh ones so the current session survives. |
+
+**Request bodies**
+
+```json
+// login / register
+{ "userName": "alice", "password": "correct-horse-1" }
+
+// change-password
+{ "currentPassword": "old-1", "newPassword": "new-passw0rd", "confirmNewPassword": "new-passw0rd" }
+```
+
+**Token response** (login / register / guest / refresh / change-password):
+
+```json
+{
+  "accessToken": "eyJhbGciOi...",
+  "accessTokenExpiresUtc": "2026-01-01T12:34:56Z",
+  "userName": "alice",
+  "role": "User",
+  "isGuest": false
+}
+```
+
+Password rules: minimum 8 characters, at least one digit and one lowercase letter.
+
+---
+
+## Catalog — `/api/v1/states` (Bearer; guests allowed)
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/states` | Supported states. |
+| GET | `/states/{state}/forms` | Calculation forms for a state (e.g. `AL` → CS-42, CS-42-S). |
+
+## Calculations — `/api/v1/states/{state}/forms/{form}/calculations` (Bearer; guests allowed)
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/states/AL/forms/CS42/calculations` | Run a calculation. Unknown state/form pairs return 404. |
+
+**Request**
+
+```json
+{
+  "numberOfChildren": 2,
+  "plaintiff": {
+    "hasPrimaryCustody": true,
+    "monthlyGrossIncome": 4200,
+    "preexistingChildSupport": 0,
+    "preexistingAlimony": 0,
+    "workRelatedChildcareCosts": 400,
+    "healthcareCoverageCosts": 250
+  },
+  "defendant": {
+    "hasPrimaryCustody": false,
+    "monthlyGrossIncome": 5100,
+    "preexistingChildSupport": 0,
+    "preexistingAlimony": 0,
+    "workRelatedChildcareCosts": 0,
+    "healthcareCoverageCosts": 0
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "success": true,
+  "errors": [],
+  "state": "AL",
+  "form": "CS42",
+  "numberOfChildren": 2,
+  "payer": "Defendant",
+  "finalAmount": 812
+}
+```
+
+`errors[]` entries carry `code`, `message`, optional `field`, and `severity` when validation of the inputs fails (`success: false`).
+
+---
+
+## Parents — `/api/v1/parents` (Bearer)
+
+Saved parent profiles. **Ownership-scoped**: every query filters by the authenticated user; you can never read or modify another user's records.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| GET | `/parents` | Bearer | List your saved parents. |
+| GET | `/parents/{id}` | Bearer | Fetch one (404 if not yours). |
+| POST | `/parents` | NotGuest | Create. `displayName` is the natural key — re-saving an existing name updates that record in place. |
+| PUT | `/parents/{id}` | NotGuest | Update. Optimistic concurrency: echo the `rowVersion` from a prior GET; a stale value returns **409 Conflict**. |
+| POST | `/parents/{id}/archive` | NotGuest | Archive (soft delete). |
+
+**Create/Update body**
+
+```json
+{
+  "displayName": "Jane D",
+  "monthlyGrossIncome": 4000,
+  "preexistingChildSupport": 0,
+  "preexistingAlimony": 0,
+  "workRelatedChildcareCosts": 300,
+  "healthcareCoverageCosts": 150,
+  "hasPrimaryCustody": true,
+  "rowVersion": "AAAAAAAAB9E="   // PUT only, optional but recommended
+}
+```
+
+---
+
+## Admin — `/api/v1/admin/users` (Bearer + Admin role)
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/admin/users?filter=all\|enabled\|disabled` | List users. |
+| GET | `/admin/users/{id}` | Fetch one user. |
+| POST | `/admin/users` | Create: `{ "userName", "password", "confirmPassword", "role": "User"\|"Admin" }`. |
+| PUT | `/admin/users/{id}` | Update: `{ "id", "userName", "role", "isDisabled" }`. Disabling a user kills their refresh path immediately. |
+| POST | `/admin/users/{id}/reset-password` | `{ "newPassword", "confirmNewPassword" }` → 204. Clears any lockout and revokes all of the user's refresh tokens. |
+| DELETE | `/admin/users/{id}` | Delete. Self-delete is rejected (400). |
+
+---
+
+## Misc
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| GET | `/healthz` | none | Liveness probe: `{ "status": "ok" }`. Exempt from rate limiting. |
+
+---
+
+## Security behaviors to expect (summary)
+
+These are features, not bugs, when testing:
+
+- `POST /auth/register` → 403 unless the operator enabled self-registration.
+- 11th auth request within a minute → 429.
+- Reused refresh cookie → 401 (rotation detected).
+- Guest token on any NotGuest/Admin endpoint → 403.
+- Password change/reset kills every other session for that user (outstanding *access* tokens survive up to 30 minutes by design — they are not revocable).
+- Production deployments serve no `/swagger`, no stack traces, and CORS only for the configured web origin.

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,7 +47,7 @@ POST /api/v1/auth/logout (cookie) ──► 204, cookie consumed + cleared
 | GET | `/auth/config` | none | Server capabilities: `{ "allowSelfRegistration": bool }`. |
 | POST | `/auth/register` | none | Create an account. Returns **403** when self-registration is disabled (the default). |
 | POST | `/auth/login` | none | Exchange credentials for tokens. |
-| POST | `/auth/guest` | none | Issue a guest session (no body). |
+| POST | `/auth/guest` | none | Issue a guest session. Takes no request body; returns the standard token response below. |
 | POST | `/auth/refresh` | refresh cookie | Rotate the refresh token, get a new access token. |
 | POST | `/auth/logout` | refresh cookie | Revoke the presented refresh token, clear the cookie. 204. |
 | POST | `/auth/change-password` | Bearer, NotGuest | Change your own password. Revokes **all** of your refresh tokens, then returns fresh ones so the current session survives. |

--- a/docs/FairShare.postman_collection.json
+++ b/docs/FairShare.postman_collection.json
@@ -1,0 +1,505 @@
+﻿{
+  "info": {
+    "name": "FairShare API",
+    "description": "FairShare child-support calculator API (v8.0.0).\n\nQuick start:\n1. Set `adminUser` / `adminPassword` in the collection variables (or an environment).\n2. Run **Auth / Login** â€” it stores `accessToken` automatically; every other request uses it via collection-level Bearer auth.\n3. Tokens expire after 30 minutes â€” re-run Login or Refresh.\n\nNotes:\n- login/register/guest/refresh share a 10 req/min per-IP rate limit â†’ expect 429 + Retry-After on bursts (by design).\n- The refresh token is an HttpOnly cookie (`fairshare_refresh`) handled by Postman's cookie jar; it rotates on every use, so replaying an old value returns 401.\n- Validation errors come back as RFC 7807 problem details with an `errors` object keyed by error code.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://localhost:5080" },
+    { "key": "adminUser", "value": "CHANGE_ME" },
+    { "key": "adminPassword", "value": "CHANGE_ME" },
+    { "key": "accessToken", "value": "" },
+    { "key": "parentId", "value": "" },
+    { "key": "parentRowVersion", "value": "" },
+    { "key": "createdUserId", "value": "" }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Get Auth Config",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/config", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "config"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.test('registration disabled', () => pm.expect(pm.response.json().allowSelfRegistration).to.be.false);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"userName\": \"{{adminUser}}\",\n  \"password\": \"{{adminPassword}}\"\n}" },
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/login", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "login"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const json = pm.response.json();",
+                  "pm.test('has access token', () => pm.expect(json.accessToken).to.be.a('string').and.not.empty);",
+                  "pm.collectionVariables.set('accessToken', json.accessToken);",
+                  "console.log('accessToken stored; role=' + json.role + ', expires ' + json.accessTokenExpiresUtc);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Continue as Guest",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/guest", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "guest"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const json = pm.response.json();",
+                  "pm.test('is guest', () => pm.expect(json.isGuest).to.be.true);",
+                  "// Overwrites the stored token with the GUEST token - re-run Login to get admin back.",
+                  "pm.collectionVariables.set('accessToken', json.accessToken);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Refresh",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/refresh", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "refresh"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK (401 means no/stale refresh cookie - run Login first)', () => pm.response.to.have.status(200));",
+                  "if (pm.response.code === 200) { pm.collectionVariables.set('accessToken', pm.response.json().accessToken); }"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Logout",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/logout", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "logout"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('204 No Content', () => pm.response.to.have.status(204));",
+                  "pm.collectionVariables.set('accessToken', '');"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Register (expect 403 - disabled)",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"userName\": \"someone-new\",\n  \"password\": \"Password-1\"\n}" },
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/register", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "register"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('403 while self-registration is disabled', () => pm.response.to.have.status(403));",
+                  "pm.test('problem details body', () => pm.expect(pm.response.json().title).to.include('Self-registration'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Change Password",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"currentPassword\": \"{{adminPassword}}\",\n  \"newPassword\": \"NewPassword-1\",\n  \"confirmNewPassword\": \"NewPassword-1\"\n}" },
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/change-password", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "change-password"] },
+            "description": "Requires Bearer (non-guest). CAREFUL: actually changes the signed-in user's password and signs out all other sessions. Wrong current password -> 400 with PasswordMismatch; guest token -> 403."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "if (pm.response.code === 200) {",
+                  "    pm.collectionVariables.set('accessToken', pm.response.json().accessToken);",
+                  "    console.log('Password changed - update the adminPassword collection variable!');",
+                  "}"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Catalog & Calculations",
+      "item": [
+        {
+          "name": "List States",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/states", "host": ["{{baseUrl}}"], "path": ["api", "v1", "states"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.test('contains AL', () => pm.expect(pm.response.json().map(s => s.state)).to.include('AL'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "List Forms for AL",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/states/AL/forms", "host": ["{{baseUrl}}"], "path": ["api", "v1", "states", "AL", "forms"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('200 OK', () => pm.response.to.have.status(200));"] }
+            }
+          ]
+        },
+        {
+          "name": "Calculate CS-42",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"numberOfChildren\": 2,\n  \"plaintiff\": {\n    \"hasPrimaryCustody\": true,\n    \"monthlyGrossIncome\": 4200,\n    \"preexistingChildSupport\": 0,\n    \"preexistingAlimony\": 0,\n    \"workRelatedChildcareCosts\": 400,\n    \"healthcareCoverageCosts\": 250\n  },\n  \"defendant\": {\n    \"hasPrimaryCustody\": false,\n    \"monthlyGrossIncome\": 5100,\n    \"preexistingChildSupport\": 0,\n    \"preexistingAlimony\": 0,\n    \"workRelatedChildcareCosts\": 0,\n    \"healthcareCoverageCosts\": 0\n  }\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/states/AL/forms/CS42/calculations", "host": ["{{baseUrl}}"], "path": ["api", "v1", "states", "AL", "forms", "CS42", "calculations"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const json = pm.response.json();",
+                  "pm.test('calculation succeeded', () => pm.expect(json.success).to.be.true);",
+                  "console.log('Payer: ' + json.payer + ', amount: ' + json.finalAmount);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Parents",
+      "item": [
+        {
+          "name": "List Parents",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/parents", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('200 OK', () => pm.response.to.have.status(200));"] }
+            }
+          ]
+        },
+        {
+          "name": "Create Parent",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"displayName\": \"Postman Test Parent\",\n  \"monthlyGrossIncome\": 4000,\n  \"preexistingChildSupport\": 0,\n  \"preexistingAlimony\": 0,\n  \"workRelatedChildcareCosts\": 300,\n  \"healthcareCoverageCosts\": 150,\n  \"hasPrimaryCustody\": true\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/parents", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents"] },
+            "description": "Guests get 403 (NotGuest policy). Saves parentId + parentRowVersion for the follow-up requests."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('201 Created', () => pm.response.to.have.status(201));",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('parentId', json.id);",
+                  "pm.collectionVariables.set('parentRowVersion', json.rowVersion || '');"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get Parent by Id",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/parents/{{parentId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents", "{{parentId}}"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.collectionVariables.set('parentRowVersion', pm.response.json().rowVersion || '');"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Update Parent",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"displayName\": \"Postman Test Parent (renamed)\",\n  \"monthlyGrossIncome\": 4500,\n  \"preexistingChildSupport\": 0,\n  \"preexistingAlimony\": 0,\n  \"workRelatedChildcareCosts\": 300,\n  \"healthcareCoverageCosts\": 150,\n  \"hasPrimaryCustody\": true,\n  \"rowVersion\": \"{{parentRowVersion}}\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/parents/{{parentId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents", "{{parentId}}"] },
+            "description": "A stale rowVersion returns 409 Conflict - re-run Get Parent by Id to refresh it."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "if (pm.response.code === 200) { pm.collectionVariables.set('parentRowVersion', pm.response.json().rowVersion || ''); }"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Archive Parent",
+          "request": {
+            "method": "POST",
+            "url": { "raw": "{{baseUrl}}/api/v1/parents/{{parentId}}/archive", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents", "{{parentId}}", "archive"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('success', () => pm.expect(pm.response.code).to.be.oneOf([200, 204]));"] }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Admin",
+      "item": [
+        {
+          "name": "List Users",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/admin/users?filter=all",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "admin", "users"],
+              "query": [{ "key": "filter", "value": "all", "description": "all | enabled | disabled" }]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('200 OK (403 = not an Admin token)', () => pm.response.to.have.status(200));"] }
+            }
+          ]
+        },
+        {
+          "name": "Create User",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userName\": \"postman-test-user\",\n  \"password\": \"Password-1\",\n  \"confirmPassword\": \"Password-1\",\n  \"role\": \"User\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('201 Created', () => pm.response.to.have.status(201));",
+                  "if (pm.response.code === 201) { pm.collectionVariables.set('createdUserId', pm.response.json().id); }"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Get User by Id",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('200 OK', () => pm.response.to.have.status(200));"] }
+            }
+          ]
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\": \"{{createdUserId}}\",\n  \"userName\": \"postman-test-user\",\n  \"role\": \"User\",\n  \"isDisabled\": false\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('204 No Content', () => pm.response.to.have.status(204));"] }
+            }
+          ]
+        },
+        {
+          "name": "Reset User Password",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"newPassword\": \"Password-2\",\n  \"confirmNewPassword\": \"Password-2\"\n}" },
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}/reset-password", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}", "reset-password"] },
+            "description": "204 on success; revokes all of that user's refresh tokens and clears any lockout."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('204 No Content', () => pm.response.to.have.status(204));"] }
+            }
+          ]
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "method": "DELETE",
+            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}"] },
+            "description": "Self-delete is blocked (400)."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": { "type": "text/javascript", "exec": ["pm.test('204 No Content', () => pm.response.to.have.status(204));"] }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Misc",
+      "item": [
+        {
+          "name": "Health Check",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "url": { "raw": "{{baseUrl}}/healthz", "host": ["{{baseUrl}}"], "path": ["healthz"] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.test('status ok', () => pm.expect(pm.response.json().status).to.eql('ok'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Rate Limit Demo (run 11+ times fast)",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": { "mode": "raw", "raw": "{\n  \"userName\": \"no-such-user\",\n  \"password\": \"wrong-on-purpose\"\n}" },
+            "url": { "raw": "{{baseUrl}}/api/v1/auth/login", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "login"] },
+            "description": "Uses a nonexistent user so no real account gets locked out. Requests 1-10 in a minute return 401; the 11th returns 429 with Retry-After: 60. NOTE: this burns the shared per-IP auth budget, so Login will also 429 until the window resets."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('401 (under limit) or 429 (throttled)', () => pm.expect(pm.response.code).to.be.oneOf([401, 429]));",
+                  "if (pm.response.code === 429) {",
+                  "    pm.test('has Retry-After', () => pm.expect(pm.response.headers.get('Retry-After')).to.eql('60'));",
+                  "}"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/FairShare.postman_collection.json
+++ b/docs/FairShare.postman_collection.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "info": {
     "name": "FairShare API",
-    "description": "FairShare child-support calculator API (v8.0.0).\n\nQuick start:\n1. Set `adminUser` / `adminPassword` in the collection variables (or an environment).\n2. Run **Auth / Login** â€” it stores `accessToken` automatically; every other request uses it via collection-level Bearer auth.\n3. Tokens expire after 30 minutes â€” re-run Login or Refresh.\n\nNotes:\n- login/register/guest/refresh share a 10 req/min per-IP rate limit â†’ expect 429 + Retry-After on bursts (by design).\n- The refresh token is an HttpOnly cookie (`fairshare_refresh`) handled by Postman's cookie jar; it rotates on every use, so replaying an old value returns 401.\n- Validation errors come back as RFC 7807 problem details with an `errors` object keyed by error code.",
+    "description": "FairShare child-support calculator API (v8.0.0).\n\nQuick start:\n1. Set `adminUser` / `adminPassword` in the collection variables (or an environment).\n2. Run **Auth / Login** — it stores `accessToken` automatically; every other request uses it via collection-level Bearer auth.\n3. Tokens expire after 30 minutes — re-run Login or Refresh.\n\nNotes:\n- login/register/guest/refresh share a 10 req/min per-IP rate limit → expect 429 + Retry-After on bursts (by design).\n- The refresh token is an HttpOnly cookie (`fairshare_refresh`) handled by Postman's cookie jar; it rotates on every use, so replaying an old value returns 401.\n- Validation errors come back as RFC 7807 problem details with an `errors` object keyed by error code.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {
@@ -102,7 +102,7 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('200 OK (401 means no/stale refresh cookie - run Login first)', () => pm.response.to.have.status(200));",
+                  "pm.test('200 (refreshed) or 401 (no/stale refresh cookie - run Login first)', () => pm.expect(pm.response.code).to.be.oneOf([200, 401]));",
                   "if (pm.response.code === 200) { pm.collectionVariables.set('accessToken', pm.response.json().accessToken); }"
                 ]
               }

--- a/docs/FairShare.postman_collection.json
+++ b/docs/FairShare.postman_collection.json
@@ -26,7 +26,7 @@
           "request": {
             "auth": { "type": "noauth" },
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/config", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "config"] }
+            "url": "{{baseUrl}}/api/v1/auth/config"
           },
           "event": [
             {
@@ -48,7 +48,7 @@
             "method": "POST",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": { "mode": "raw", "raw": "{\n  \"userName\": \"{{adminUser}}\",\n  \"password\": \"{{adminPassword}}\"\n}" },
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/login", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "login"] }
+            "url": "{{baseUrl}}/api/v1/auth/login"
           },
           "event": [
             {
@@ -71,7 +71,7 @@
           "request": {
             "auth": { "type": "noauth" },
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/guest", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "guest"] }
+            "url": "{{baseUrl}}/api/v1/auth/guest"
           },
           "event": [
             {
@@ -94,7 +94,7 @@
           "request": {
             "auth": { "type": "noauth" },
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/refresh", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "refresh"] }
+            "url": "{{baseUrl}}/api/v1/auth/refresh"
           },
           "event": [
             {
@@ -114,7 +114,7 @@
           "request": {
             "auth": { "type": "noauth" },
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/logout", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "logout"] }
+            "url": "{{baseUrl}}/api/v1/auth/logout"
           },
           "event": [
             {
@@ -136,7 +136,7 @@
             "method": "POST",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": { "mode": "raw", "raw": "{\n  \"userName\": \"someone-new\",\n  \"password\": \"Password-1\"\n}" },
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/register", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "register"] }
+            "url": "{{baseUrl}}/api/v1/auth/register"
           },
           "event": [
             {
@@ -157,7 +157,7 @@
             "method": "POST",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": { "mode": "raw", "raw": "{\n  \"currentPassword\": \"{{adminPassword}}\",\n  \"newPassword\": \"NewPassword-1\",\n  \"confirmNewPassword\": \"NewPassword-1\"\n}" },
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/change-password", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "change-password"] },
+            "url": "{{baseUrl}}/api/v1/auth/change-password",
             "description": "Requires Bearer (non-guest). CAREFUL: actually changes the signed-in user's password and signs out all other sessions. Wrong current password -> 400 with PasswordMismatch; guest token -> 403."
           },
           "event": [
@@ -185,7 +185,7 @@
           "name": "List States",
           "request": {
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/api/v1/states", "host": ["{{baseUrl}}"], "path": ["api", "v1", "states"] }
+            "url": "{{baseUrl}}/api/v1/states"
           },
           "event": [
             {
@@ -204,7 +204,7 @@
           "name": "List Forms for AL",
           "request": {
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/api/v1/states/AL/forms", "host": ["{{baseUrl}}"], "path": ["api", "v1", "states", "AL", "forms"] }
+            "url": "{{baseUrl}}/api/v1/states/AL/forms"
           },
           "event": [
             {
@@ -222,7 +222,7 @@
               "mode": "raw",
               "raw": "{\n  \"numberOfChildren\": 2,\n  \"plaintiff\": {\n    \"hasPrimaryCustody\": true,\n    \"monthlyGrossIncome\": 4200,\n    \"preexistingChildSupport\": 0,\n    \"preexistingAlimony\": 0,\n    \"workRelatedChildcareCosts\": 400,\n    \"healthcareCoverageCosts\": 250\n  },\n  \"defendant\": {\n    \"hasPrimaryCustody\": false,\n    \"monthlyGrossIncome\": 5100,\n    \"preexistingChildSupport\": 0,\n    \"preexistingAlimony\": 0,\n    \"workRelatedChildcareCosts\": 0,\n    \"healthcareCoverageCosts\": 0\n  }\n}"
             },
-            "url": { "raw": "{{baseUrl}}/api/v1/states/AL/forms/CS42/calculations", "host": ["{{baseUrl}}"], "path": ["api", "v1", "states", "AL", "forms", "CS42", "calculations"] }
+            "url": "{{baseUrl}}/api/v1/states/AL/forms/CS42/calculations"
           },
           "event": [
             {
@@ -248,7 +248,7 @@
           "name": "List Parents",
           "request": {
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/api/v1/parents", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents"] }
+            "url": "{{baseUrl}}/api/v1/parents"
           },
           "event": [
             {
@@ -266,7 +266,7 @@
               "mode": "raw",
               "raw": "{\n  \"displayName\": \"Postman Test Parent\",\n  \"monthlyGrossIncome\": 4000,\n  \"preexistingChildSupport\": 0,\n  \"preexistingAlimony\": 0,\n  \"workRelatedChildcareCosts\": 300,\n  \"healthcareCoverageCosts\": 150,\n  \"hasPrimaryCustody\": true\n}"
             },
-            "url": { "raw": "{{baseUrl}}/api/v1/parents", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents"] },
+            "url": "{{baseUrl}}/api/v1/parents",
             "description": "Guests get 403 (NotGuest policy). Saves parentId + parentRowVersion for the follow-up requests."
           },
           "event": [
@@ -288,7 +288,7 @@
           "name": "Get Parent by Id",
           "request": {
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/api/v1/parents/{{parentId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents", "{{parentId}}"] }
+            "url": "{{baseUrl}}/api/v1/parents/{{parentId}}"
           },
           "event": [
             {
@@ -312,7 +312,7 @@
               "mode": "raw",
               "raw": "{\n  \"displayName\": \"Postman Test Parent (renamed)\",\n  \"monthlyGrossIncome\": 4500,\n  \"preexistingChildSupport\": 0,\n  \"preexistingAlimony\": 0,\n  \"workRelatedChildcareCosts\": 300,\n  \"healthcareCoverageCosts\": 150,\n  \"hasPrimaryCustody\": true,\n  \"rowVersion\": \"{{parentRowVersion}}\"\n}"
             },
-            "url": { "raw": "{{baseUrl}}/api/v1/parents/{{parentId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents", "{{parentId}}"] },
+            "url": "{{baseUrl}}/api/v1/parents/{{parentId}}",
             "description": "A stale rowVersion returns 409 Conflict - re-run Get Parent by Id to refresh it."
           },
           "event": [
@@ -332,7 +332,7 @@
           "name": "Archive Parent",
           "request": {
             "method": "POST",
-            "url": { "raw": "{{baseUrl}}/api/v1/parents/{{parentId}}/archive", "host": ["{{baseUrl}}"], "path": ["api", "v1", "parents", "{{parentId}}", "archive"] }
+            "url": "{{baseUrl}}/api/v1/parents/{{parentId}}/archive"
           },
           "event": [
             {
@@ -350,17 +350,13 @@
           "name": "List Users",
           "request": {
             "method": "GET",
-            "url": {
-              "raw": "{{baseUrl}}/api/v1/admin/users?filter=all",
-              "host": ["{{baseUrl}}"],
-              "path": ["api", "v1", "admin", "users"],
-              "query": [{ "key": "filter", "value": "all", "description": "all | enabled | disabled" }]
-            }
+            "url": "{{baseUrl}}/api/v1/admin/users?filter=all",
+            "description": "filter accepts all | enabled | disabled. A 403 means the current token lacks the Admin role - re-run Login with admin credentials."
           },
           "event": [
             {
               "listen": "test",
-              "script": { "type": "text/javascript", "exec": ["pm.test('200 OK (403 = not an Admin token)', () => pm.response.to.have.status(200));"] }
+              "script": { "type": "text/javascript", "exec": ["pm.test('200 OK', () => pm.response.to.have.status(200));"] }
             }
           ]
         },
@@ -373,7 +369,7 @@
               "mode": "raw",
               "raw": "{\n  \"userName\": \"postman-test-user\",\n  \"password\": \"Password-1\",\n  \"confirmPassword\": \"Password-1\",\n  \"role\": \"User\"\n}"
             },
-            "url": { "raw": "{{baseUrl}}/api/v1/admin/users", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users"] }
+            "url": "{{baseUrl}}/api/v1/admin/users"
           },
           "event": [
             {
@@ -392,7 +388,7 @@
           "name": "Get User by Id",
           "request": {
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}"] }
+            "url": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}"
           },
           "event": [
             {
@@ -410,7 +406,7 @@
               "mode": "raw",
               "raw": "{\n  \"id\": \"{{createdUserId}}\",\n  \"userName\": \"postman-test-user\",\n  \"role\": \"User\",\n  \"isDisabled\": false\n}"
             },
-            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}"] }
+            "url": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}"
           },
           "event": [
             {
@@ -425,7 +421,7 @@
             "method": "POST",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": { "mode": "raw", "raw": "{\n  \"newPassword\": \"Password-2\",\n  \"confirmNewPassword\": \"Password-2\"\n}" },
-            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}/reset-password", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}", "reset-password"] },
+            "url": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}/reset-password",
             "description": "204 on success; revokes all of that user's refresh tokens and clears any lockout."
           },
           "event": [
@@ -439,7 +435,7 @@
           "name": "Delete User",
           "request": {
             "method": "DELETE",
-            "url": { "raw": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}", "host": ["{{baseUrl}}"], "path": ["api", "v1", "admin", "users", "{{createdUserId}}"] },
+            "url": "{{baseUrl}}/api/v1/admin/users/{{createdUserId}}",
             "description": "Self-delete is blocked (400)."
           },
           "event": [
@@ -459,7 +455,7 @@
           "request": {
             "auth": { "type": "noauth" },
             "method": "GET",
-            "url": { "raw": "{{baseUrl}}/healthz", "host": ["{{baseUrl}}"], "path": ["healthz"] }
+            "url": "{{baseUrl}}/healthz"
           },
           "event": [
             {
@@ -481,7 +477,7 @@
             "method": "POST",
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": { "mode": "raw", "raw": "{\n  \"userName\": \"no-such-user\",\n  \"password\": \"wrong-on-purpose\"\n}" },
-            "url": { "raw": "{{baseUrl}}/api/v1/auth/login", "host": ["{{baseUrl}}"], "path": ["api", "v1", "auth", "login"] },
+            "url": "{{baseUrl}}/api/v1/auth/login",
             "description": "Uses a nonexistent user so no real account gets locked out. Requests 1-10 in a minute return 401; the 11th returns 429 with Retry-After: 60. NOTE: this burns the shared per-IP auth budget, so Login will also 429 until the window resets."
           },
           "event": [

--- a/src/FairShare.Api/README.md
+++ b/src/FairShare.Api/README.md
@@ -1,0 +1,27 @@
+# FairShare.Api
+
+ASP.NET Core Web API — auth, persistence, and the HTTP surface for everything in [`docs/API.md`](../../docs/API.md).
+
+## Responsibilities
+
+- **Auth**: ASP.NET Identity (SQLite via EF Core) + JWT bearer access tokens and single-use rotating refresh tokens (`Auth/TokenService.cs`). Login lockout, uniform 401s, registration gate (`Auth:AllowSelfRegistration`, default off).
+- **Controllers** (`Controllers/`): `AuthController` (login/refresh/guest/change-password), `UsersController` (admin CRUD + password reset), `ParentsController` (ownership-scoped profiles with optimistic concurrency), `CatalogController` + `CalculationsController` (thin HTTP wrappers over `FairShare.Domain`).
+- **Startup** (`Program.cs`): single-file minimal hosting — Identity/JWT config, rate limiting (per-IP, strict policy on the auth endpoints, `/healthz` exempt), CORS pinned to configured origins, forwarded-proto handling for reverse proxies, and the auto-migrate block (SQLite integrity check + pre-migration zip backup before applying migrations).
+- **Background work** (`Services/`): `AdminSeeder` (first-boot admin account) and `RefreshTokenCleanupService` (purges expired/stale-revoked refresh tokens every 6 h).
+
+## Key conventions
+
+- Every data query is scoped to the authenticated user's id — never trust a record id alone.
+- Failures return RFC 7807 problem details; validation errors are grouped by Identity error code.
+- Config comes from `appsettings.json` < `appsettings.{Env}.json` < environment variables (`Section__Key`). Docker maps `.env` values in `docker-compose.yml`. See the configuration table in the root README.
+- Swagger UI is registered only in Development. Don't move it out of that block for a public deployment.
+- New schema changes = a new EF migration in `Migrations/`; the startup block applies them (backup first) when `AutoMigrate` is true.
+
+## Run
+
+```bash
+dotnet run                    # https://localhost:7080, Swagger at /swagger
+dotnet test ../FairShare.Tests # integration tests boot this project in-memory
+```
+
+Dev uses `appsettings.Development.json` (committed dev signing key, local `fairshare.db`) — safe to experiment, never reuse those values in production.

--- a/src/FairShare.Contracts/README.md
+++ b/src/FairShare.Contracts/README.md
@@ -1,0 +1,19 @@
+# FairShare.Contracts
+
+Wire DTOs shared by the API and the Blazor SPA — the single source of truth for every request/response shape. Referenced by both `FairShare.Api` and `FairShare.Web`, so a change here updates both sides of the wire at compile time.
+
+## Layout
+
+| File | Shapes |
+|---|---|
+| `Auth/AuthContracts.cs` | `LoginRequest`, `RegisterRequest`, `ChangePasswordRequest`, `AuthTokenResponse`, `AuthConfigResponse` |
+| `Admin/AdminContracts.cs` | `UserListItem`, `CreateUserRequest`, `EditUserRequest`, `AdminResetPasswordRequest` |
+| `Parents/ParentContracts.cs` | `ParentProfileDto`, `ParentProfileCreateRequest`, `ParentProfileUpdateRequest` (incl. `RowVersion` for optimistic concurrency) |
+| `Calculation/CalculationContracts.cs` | `CalculationRequest`, `ParentDataDto`, `CalculationResponse`, `CalcErrorDto` |
+| `Catalog/CatalogContracts.cs` | State/form summaries for the catalog endpoints |
+
+## Rules
+
+- DTOs only: no behavior, no EF entities, no domain logic. Validation via data annotations is fine (both the API's model binding and Blazor's `EditForm` honor them — one set of rules, enforced on both ends).
+- Keep this project free of ASP.NET/EF dependencies; it must stay referenceable from Blazor WebAssembly.
+- Renaming or removing a property is a breaking wire change — the SPA and API deploy separately in Docker, so version them together.

--- a/src/FairShare.Domain/README.md
+++ b/src/FairShare.Domain/README.md
@@ -1,0 +1,25 @@
+# FairShare.Domain
+
+The pure calculation engine. No ASP.NET, no EF, no Identity — just deterministic child-support math that both the API (and, in principle, any other host) can call. If you're changing how support is computed, this is the only project you should need to touch.
+
+## Layout
+
+- `Calculators/`
+  - `BaseChildSupportCalculator` — shared validation and calculation plumbing.
+  - `CS42Calculator` — Alabama CS-42 (standard custody) worksheet.
+  - `CS42SCalculator` — Alabama CS-42-S (shared parenting) worksheet.
+- `Seeds/BcsoLookup.cs` — Alabama's Basic Child Support Obligation schedule (the income × children lookup table the worksheets are built on).
+- `Models/ParentData.cs` — plain input model (income, preexisting support/alimony, childcare and healthcare costs, custody flag).
+- `Helpers/` — `CalculationResult` (success flag, payer, final amount), `CalcError` (code/message/field/severity), shared enums.
+- `Interfaces/` + `Services/StateGuidelineCatalog.cs` — `IChildSupportCalculator` is the contract every worksheet implements; the catalog maps `(state, form)` → calculator and backs the API's `/states` endpoints.
+
+## Adding a new state or form
+
+1. Implement `IChildSupportCalculator` (extend `BaseChildSupportCalculator` where the plumbing fits).
+2. Register it in DI (see the "Domain services" block in `FairShare.Api/Program.cs`) — `StateGuidelineCatalog` discovers calculators from DI, and the new form shows up in the catalog endpoints automatically.
+3. Add unit tests in `FairShare.Tests/Domain/` — calculators are pure, so tests are plain input/output assertions with no test host.
+
+## Rules
+
+- Keep this project dependency-free (no web/persistence packages). Anything that needs HTTP or a database belongs in `FairShare.Api`.
+- Calculators must be deterministic and side-effect-free; report input problems via `CalcError` entries on the result, don't throw.

--- a/src/FairShare.Tests/README.md
+++ b/src/FairShare.Tests/README.md
@@ -1,0 +1,25 @@
+# FairShare.Tests
+
+xUnit test project covering both layers:
+
+- `Domain/` — pure unit tests for the calculators (`CS42CalculatorTests`, `CS42SCalculatorTests`). No host, no mocks — calculators are deterministic functions.
+- `Api/` — end-to-end integration tests that boot the real API in-memory via `WebApplicationFactory<Program>` against a throwaway SQLite database.
+
+## The API test harness
+
+`FairShareApiFactory` is the shared fixture. Notable design points (read its comments before changing it):
+
+- **Config via process environment variables**, not `ConfigureAppConfiguration` — env vars outrank `appsettings.Development.json` in host config precedence, which is the only way overrides reliably win with minimal-hosting apps. Originals are restored on dispose.
+- Each fixture gets a **unique temp SQLite file**, deleted on dispose (after clearing the connection pool).
+- **Rate limiting is disabled** in the base factory (`RateLimiting__Enabled=false`) so functional tests can hammer auth endpoints; `RateLimitingTests` re-enables it via a factory subclass to test the 429 path itself.
+- All API test classes share the `[Collection("Api")]` collection so they run **sequentially** — parallel in-process test hosts flake on shared native SQLite init, and the env-var mechanism is process-wide.
+- Test clients use an `https://localhost` base address so the Secure refresh cookie round-trips; the `HandleCookies = false` pattern (see `AuthEndpointsTests`) is used whenever a test needs to replay a specific stale cookie instead of letting the cookie jar rotate it away.
+
+## Adding tests
+
+- New feature with config? Subclass `FairShareApiFactory`, call `base.ConfigureWebHost(builder)`, then `SetEnvVar(...)` your overrides (see `RegistrationEnabledApiFactory`).
+- Self-registration is disabled by default, so create extra users through the admin API (login as the seeded admin `admin` / `Adm!n-Test-12345` — test-fixture values only), not `/auth/register`.
+
+```bash
+dotnet test FairShare.sln
+```

--- a/src/FairShare.Web/README.md
+++ b/src/FairShare.Web/README.md
@@ -1,0 +1,25 @@
+# FairShare.Web
+
+Standalone Blazor WebAssembly SPA. Compiled to static WASM assets and served by nginx (Docker) or Kestrel (`dotnet run`); all data comes from `FairShare.Api` over HTTP/JSON — the browser calls the API directly, cross-origin.
+
+## Layout
+
+- `Auth/` — the client-side auth machinery:
+  - `AuthApiClient` — typed wrapper for the `/api/v1/auth/*` endpoints; caches the server's auth-config flags (fail-closed).
+  - `AuthTokenHandler` — `DelegatingHandler` that attaches the bearer token and, on 401, performs one serialized silent refresh + retry (skipped for anonymous auth endpoints so a failed login can't "succeed" via refresh).
+  - `InMemoryTokenStore` — the access token lives in memory only (XSS hardening); page reloads re-hydrate via the HttpOnly refresh cookie (`Program.cs` calls `TryRefreshAsync()` before first render).
+  - `JwtAuthenticationStateProvider` / `JwtParser` — claims → `AuthenticationState`; policies `AdminOnly` and `NotGuest` mirror the API's.
+- `Pages/` — `Calculator`, `StateForms`, `Profiles` (saved parents), `Login`/`Register` (registration UI hides itself when the server reports self-registration disabled), `ChangePassword`, `Admin/*` (user management).
+- `Components/`, `Layout/` — Bootstrap 5 UI; `ThemeToggle` persists light/dark/auto in `localStorage`, applied pre-render by `wwwroot/js/theme-init.js` (a separate file, not an inline script, so the CSP can stay `script-src 'self'`).
+- `nginx.conf` + `fairshare-security-headers.inc` — production web server config: SPA fallback, cache policy, and CSP/security headers (the `.inc` is re-included in every location that sets its own `add_header`; nginx header inheritance is all-or-nothing).
+- `docker-entrypoint.d/` — container-start scripts: `40-…` writes `Api:BaseUrl` from `API_BASE_URL`, `50-…` injects the API origin into the CSP `connect-src`. Both make the image deploy-agnostic without rebuilds.
+
+## Runtime config
+
+The SPA reads exactly one setting: `Api:BaseUrl` (`wwwroot/appsettings.json`, overwritten at container start). It must be the **browser-visible** API URL. Web and API must be served over the same scheme (both HTTPS or both HTTP) or browsers block the calls as mixed content.
+
+## Run
+
+```bash
+dotnet run   # https://localhost:7090, expects the API on localhost:7080
+```


### PR DESCRIPTION
## Summary

Developer-facing documentation pass:

- **`docs/API.md`** — full API reference: auth model (JWT + rotating refresh cookie), RFC 7807 error shapes, rate-limit behavior, and every endpoint with request/response bodies matching the Contracts DTOs. Localhost examples only; security behaviors documented as intentional.
- **`docs/FairShare.postman_collection.json`** — importable Postman collection with collection-level bearer auth, chained variables (login stores the token; create requests store ids), sample bodies, and per-request assertions. Placeholder credentials, localhost base URL.
- **Per-project READMEs** for `FairShare.Api`, `FairShare.Web`, `FairShare.Domain`, `FairShare.Contracts`, and `FairShare.Tests` — responsibilities, conventions, and extension points (e.g. how to add a new state calculator, how the test harness's env-var config works).
- **Root README corrections**: the Docker Compose quick start claimed Swagger at `:5859` (compose runs Production, which serves no `/swagger`); "What's new in v8" now leads with what 8.0.0 actually shipped (public hardening + the breaking self-registration default); solution-layout table links to the new per-project READMEs.

Docs-only change — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)