### PR TITLE
feat(web): show app version next to the footer copyright

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,11 @@
         { "type": "xml", "path": "src/FairShare.Api/FairShare.Api.csproj", "xpath": "//Project/PropertyGroup/Version" },
         { "type": "xml", "path": "src/FairShare.Api/FairShare.Api.csproj", "xpath": "//Project/PropertyGroup/AssemblyVersion" },
         { "type": "xml", "path": "src/FairShare.Api/FairShare.Api.csproj", "xpath": "//Project/PropertyGroup/FileVersion" },
-        { "type": "xml", "path": "src/FairShare.Api/FairShare.Api.csproj", "xpath": "//Project/PropertyGroup/InformationalVersion" }
+        { "type": "xml", "path": "src/FairShare.Api/FairShare.Api.csproj", "xpath": "//Project/PropertyGroup/InformationalVersion" },
+        { "type": "xml", "path": "src/FairShare.Web/FairShare.Web.csproj", "xpath": "//Project/PropertyGroup/Version" },
+        { "type": "xml", "path": "src/FairShare.Web/FairShare.Web.csproj", "xpath": "//Project/PropertyGroup/AssemblyVersion" },
+        { "type": "xml", "path": "src/FairShare.Web/FairShare.Web.csproj", "xpath": "//Project/PropertyGroup/FileVersion" },
+        { "type": "xml", "path": "src/FairShare.Web/FairShare.Web.csproj", "xpath": "//Project/PropertyGroup/InformationalVersion" }
       ]
     }
   }

--- a/src/FairShare.Web/FairShare.Web.csproj
+++ b/src/FairShare.Web/FairShare.Web.csproj
@@ -7,6 +7,10 @@
     <AssemblyName>FairShare.Web</AssemblyName>
     <RootNamespace>FairShare.Web</RootNamespace>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <FileVersion>2.0.0</FileVersion>
+    <InformationalVersion>2.0.0</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FairShare.Web/Layout/MainLayout.razor
+++ b/src/FairShare.Web/Layout/MainLayout.razor
@@ -1,3 +1,4 @@
+@using System.Reflection
 @inherits LayoutComponentBase
 
 <NavMenu />
@@ -7,5 +8,15 @@
 </main>
 
 <footer class="container small text-muted py-4">
-    &copy; @DateTime.UtcNow.Year - FairShare
+    &copy; @DateTime.UtcNow.Year - FairShare v@(AppVersion)
 </footer>
+
+@code {
+    // InformationalVersion is stamped by release-please via the csproj; the SDK's
+    // implicit SourceLink can append "+<commit-sha>", which the split strips.
+    private static readonly string AppVersion =
+        (typeof(MainLayout).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+         ?? typeof(MainLayout).Assembly.GetName().Version?.ToString(3)
+         ?? "0.0.0")
+        .Split('+')[0];
+}


### PR DESCRIPTION
## Summary

The deployed web app now shows which version it's running: the footer reads `© 2026 - FairShare v2.0.0`.

- `FairShare.Web.csproj` gains the same four version fields the API project has (set to 2.0.0)
- `release-please-config.json` adds extra-files entries so future release PRs bump the Web project alongside the API
- `MainLayout.razor` renders the version from the assembly's `InformationalVersion`, stripping the implicit-SourceLink `+<sha>` suffix (verified present in real builds), with fallbacks to `AssemblyVersion`

Verified: built assembly stamps `2.0.0+<sha>`; displayed value is `v2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)