### PR TITLE
fix(web): stop immutable-caching the unfingerprinted Blazor entry scripts

### DIFF
--- a/src/FairShare.Web/nginx.conf
+++ b/src/FairShare.Web/nginx.conf
@@ -24,6 +24,19 @@ server {
         try_files $uri =404;
     }
 
+    # The two UNfingerprinted entry files under /_framework/: they reference every
+    # fingerprinted asset by name, so caching them immutable pins returning browsers
+    # to the previous deployment forever. Exact matches outrank the prefix block.
+    location = /_framework/blazor.webassembly.js {
+        add_header Cache-Control "no-cache";
+        include /etc/nginx/conf.d/fairshare-security-headers.inc;
+    }
+
+    location = /_framework/dotnet.js {
+        add_header Cache-Control "no-cache";
+        include /etc/nginx/conf.d/fairshare-security-headers.inc;
+    }
+
     # The host page and runtime config must always be revalidated so deploys
     # and API_BASE_URL changes take effect immediately.
     location = /index.html {


### PR DESCRIPTION
## Summary

Deploys were invisible to returning browsers: `_framework/blazor.webassembly.js` and `_framework/dotnet.js` are **not** fingerprinted, but the `/_framework/` location served them with `max-age=31536000, immutable`. A returning browser revalidated `index.html` (bytes unchanged between builds), then ran the year-cached entry scripts → old boot config → old fingerprinted assemblies, entirely from cache. Only a hard refresh picked up a new deployment.

Exact-match locations now serve both entry files with `no-cache`; all fingerprinted assets keep the immutable header.

Verified on a built image: `blazor.webassembly.js`, `dotnet.js`, `index.html` → `no-cache`; `FairShare.Web.<fingerprint>.wasm` → `immutable`; security headers present on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)