### PR TITLE
feat(web): show the paying parent's name in the result sentence

### DIFF
--- a/src/FairShare.Web/Pages/Calculator.razor
+++ b/src/FairShare.Web/Pages/Calculator.razor
@@ -104,11 +104,7 @@
             <div class="card-body">
                 @if (submitted && result is not null && result.Success)
                 {
-                    <p class="fw-bold text-center mb-0">
-                        @(string.IsNullOrWhiteSpace(result.Payer)
-                            ? "No net transfer."
-                            : $"{result.Payer} owes ${result.FinalAmount}.")
-                    </p>
+                    <p class="fw-bold text-center mb-0">@ResultSentence(result)</p>
 
                     @if (result.Lines.Any())
                     {
@@ -466,6 +462,19 @@
     {
         result = null;
         submitted = false;
+    }
+
+    // "Defendant: John D. owes $50." when the paying parent has a name, "Defendant owes $50." when not.
+    private string ResultSentence(CalculationResponse calculation)
+    {
+        if (string.IsNullOrWhiteSpace(calculation.Payer))
+        {
+            return "No net transfer.";
+        }
+
+        string? name = calculation.Payer.Equals("Plaintiff", StringComparison.OrdinalIgnoreCase) ? plaintiffName : defendantName;
+        string who = string.IsNullOrWhiteSpace(name) ? calculation.Payer : $"{calculation.Payer}: {name.Trim()}";
+        return $"{who} owes ${calculation.FinalAmount}.";
     }
 
     // The last line of the worksheet is the recommended order - the row a user reads first.


### PR DESCRIPTION
## Summary

The result sentence names the paying parent when a name was entered: `Defendant: John D. owes $50.` / `Plaintiff: Jane P. owes $186.`; with a blank name it stays `Defendant owes $50.`; `No net transfer.` unchanged. One helper (`ResultSentence`) in `Calculator.razor`.

## Verification

- `dotnet build` green.
- Playwright (local API + Web) 4/4: named defendant, named plaintiff (after flipping custody), blank-name fallback, sentence survives the CS-42-S switch.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
