### PR TITLE
fix(api): skip HTTPS redirection behind the proxy; persist DataProtection keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Swagger UI is available at `/swagger` in Development. The full endpoint referenc
 | `AdminSeed:LogGeneratedPassword`    | `true`       | Whether a generated admin password is printed to the log.                              |
 | `Auth:AllowSelfRegistration`        | `false`      | Whether `POST /api/v1/auth/register` is open. Off = admin creates accounts.            |
 | `RateLimiting:Enabled`              | `true`       | Kill-switch for rate limiting (values are fixed: 100 req/min per IP globally, 10 req/min per IP on the auth endpoints). |
+| `DataProtection:KeysPath`           | *(unset)*    | Directory for ASP.NET DataProtection keys (Identity tokens). Set it to a volume path (the compose stacks use `/data/keys`) so keys survive container recreates; unset = framework default inside the container. |
+| `HttpsRedirection:HttpsPort` / `ASPNETCORE_HTTPS_PORT` | *(unset)* | Only needed when Kestrel itself serves TLS. Behind a TLS-terminating proxy leave it unset: the API then skips `UseHttpsRedirection` (the proxy forces HTTPS) instead of logging "Failed to determine the https port for redirect" on every start. |
 
 | Setting (Web)     | Default | Purpose                                    |
 | ------------------ | ------- | ------------------------------------------ |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       AdminSeed__LogGeneratedPassword: "${ADMIN_SEED_LOG_GENERATED_PASSWORD:-true}"
       Auth__AllowSelfRegistration: "${ALLOW_SELF_REGISTRATION:-false}"
       Cors__AllowedOrigins__0: "${WEB_ORIGIN:-http://localhost:5858}"
+      # DataProtection keys on the data volume so Identity tokens survive container recreates.
+      DataProtection__KeysPath: "/data/keys"
     volumes:
       - fairshare-data:/data
     healthcheck:

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -303,9 +303,12 @@ app.UseForwardedHeaders();
 // the container healthcheck's own request. Wire it only when Kestrel serves TLS
 // (Development) or an HTTPS port is configured explicitly (HttpsRedirection:HttpsPort /
 // ASPNETCORE_HTTPS_PORT); the proxy already forces HTTPS for real clients.
+// ASPNETCORE_HTTPS_PORT reaches configuration both as HTTPS_PORT (host config strips the
+// prefix) and under its full name; check both so the knob works however it was set.
 bool httpsPortConfigured =
     builder.Configuration.GetValue<int?>("HttpsRedirection:HttpsPort") is not null ||
-    !string.IsNullOrEmpty(builder.Configuration["HTTPS_PORT"]);
+    !string.IsNullOrEmpty(builder.Configuration["HTTPS_PORT"]) ||
+    !string.IsNullOrEmpty(builder.Configuration["ASPNETCORE_HTTPS_PORT"]);
 if (app.Environment.IsDevelopment() || httpsPortConfigured)
 {
     app.UseHttpsRedirection();

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
@@ -186,6 +187,17 @@ builder.Services.AddRateLimiter(options =>
     };
 });
 
+// DataProtection keys (Identity's password-reset/confirmation tokens) default to the
+// container's own filesystem, which is lost on every recreate. Point them at a volume
+// (DataProtection:KeysPath, e.g. /data/keys in the compose stacks) so they survive.
+string? dataProtectionKeysPath = builder.Configuration["DataProtection:KeysPath"];
+if (!string.IsNullOrWhiteSpace(dataProtectionKeysPath))
+{
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(new DirectoryInfo(dataProtectionKeysPath))
+        .SetApplicationName("FairShare");
+}
+
 // Behind a TLS-terminating reverse proxy (the eventual VPS setup), the app sees plain
 // HTTP; honoring X-Forwarded-Proto keeps Request.IsHttps - and everything derived from
 // it, like the refresh cookie's Secure/SameSite attributes - correct. The proxy address
@@ -285,7 +297,19 @@ else
 
 app.UseForwardedHeaders();
 
-app.UseHttpsRedirection();
+// The app itself only serves TLS in Development (dotnet run's https profile). Behind the
+// reverse proxy it listens on plain HTTP and UseHttpsRedirection has no HTTPS port to
+// redirect to - it would just log "Failed to determine the https port for redirect" on
+// the container healthcheck's own request. Wire it only when Kestrel serves TLS
+// (Development) or an HTTPS port is configured explicitly (HttpsRedirection:HttpsPort /
+// ASPNETCORE_HTTPS_PORT); the proxy already forces HTTPS for real clients.
+bool httpsPortConfigured =
+    builder.Configuration.GetValue<int?>("HttpsRedirection:HttpsPort") is not null ||
+    !string.IsNullOrEmpty(builder.Configuration["HTTPS_PORT"]);
+if (app.Environment.IsDevelopment() || httpsPortConfigured)
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseCors("Web");
 


### PR DESCRIPTION
## Root cause

Behind Nginx Proxy Manager the API listens on plain HTTP (TLS terminates upstream) but `UseHttpsRedirection` was always wired. The container healthcheck is a plain-HTTP request with no `X-Forwarded-Proto`, so the middleware looked for an HTTPS port it cannot know and logged `Failed to determine the https port for redirect` on every start. The same startup log showed DataProtection keys stored in the container filesystem (lost on every recreate).

## Changes

- `Program.cs`: `UseHttpsRedirection` only in Development or when `HttpsRedirection:HttpsPort` / `HTTPS_PORT` (`ASPNETCORE_HTTPS_PORT`) is configured; the proxy forces HTTPS for real clients (forwarded-proto handling unchanged).
- `Program.cs`: optional `DataProtection:KeysPath` → `PersistKeysToFileSystem` + `SetApplicationName("FairShare")`.
- Repo `docker-compose.yml` sets `DataProtection__KeysPath=/data/keys`; README configuration table documents both.

## Verification

- `dotnet build` / `dotnet test` — 147 passed.
- After release: the production stack (`Z:\docker\fairshare`) gets `DataProtection__KeysPath=/data/keys` and the bumped tag; startup log must show neither warning and `/data/keys` must hold the key ring.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)