### PR TITLE
fix(deps): bump Microsoft packages to 10.0.11 and adopt KnownIPNetworks

### DIFF
--- a/src/FairShare.Api/FairShare.Api.csproj
+++ b/src/FairShare.Api/FairShare.Api.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11"/>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
     <PackageReference Include="ClosedXML" Version="0.105.1"/>
   </ItemGroup>

--- a/src/FairShare.Api/FairShare.Api.csproj
+++ b/src/FairShare.Api/FairShare.Api.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.11"/>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11" PrivateAssets="all"/>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
     <PackageReference Include="ClosedXML" Version="0.105.1"/>
   </ItemGroup>

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -206,7 +206,7 @@ if (!string.IsNullOrWhiteSpace(dataProtectionKeysPath))
 builder.Services.Configure<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto;
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
 

--- a/src/FairShare.Domain/FairShare.Domain.csproj
+++ b/src/FairShare.Domain/FairShare.Domain.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/FairShare.Tests/FairShare.Tests.csproj
+++ b/src/FairShare.Tests/FairShare.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageReference Include="ClosedXML" Version="0.105.1" />
   </ItemGroup>
 

--- a/src/FairShare.Web/FairShare.Web.csproj
+++ b/src/FairShare.Web/FairShare.Web.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5"/>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Aligns every Microsoft.* package across Api / Domain / Tests / Web on **10.0.11**, matching the aspnet:10.0.11 runtime images the containers already run on.
- Consolidates dependabot PRs #57, #58, #59 (their 10.0.9 targets are stale) and covers the packages dependabot had not filed for: JwtBearer, EF Core Tools, Diagnostics.EntityFrameworkCore, Mvc.Testing, Components.Authorization, WebAssembly.DevServer, Extensions.Http (was 10.0.0), Logging.Abstractions (was 10.0.7).
- Migrates ForwardedHeadersOptions from the newly-obsolete KnownNetworks to KnownIPNetworks (ASPDEPR005 introduced by 10.0.11).

## Verification
- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: 147 passed, 0 failed.

Closes #57. Closes #58. Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)