### PR TITLE
feat!: land visitors as guests with sign-in as an account upgrade

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,13 @@ The ubiquitous language of the FairShare domain: child-support worksheets as the
 | **Payer** | The parent the recommended order applies to. "No net transfer" means neither parent owes the other. |
 | **Custodial parent** | On CS-42, the parent with primary physical custody; the other parent is the payer. CS-42-S has no custodial parent. |
 
+## Access vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Guest** | The default identity — anyone who has not signed in. A guest can calculate and export, never persist. |
+| **User / Admin** | Admin-provisioned accounts. A user additionally saves parent profiles; an admin additionally manages accounts. |
+
 ## Fidelity vocabulary
 
 | Term | Meaning |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ FairShare gives a quick, transparent estimate of who pays child support and how 
 - **Data Persistence**: Save and manage Parent Profiles (Plaintiff vs Defendant). Within your saved parents the display name is the natural key: re-saving an existing name (even with adjusted figures) updates that record in place instead of creating a same-named duplicate.
 - **Admin Tools**: Comprehensive user management and automated database seeding.
 - **Health & Safety**: Integrated database integrity checks and automated backup zipping on startup.
-- **Guest mode**: Try the calculator without creating an account (no saving).
+- **Guest-first**: Visitors land straight on the calculator as guests — no account needed to calculate or export (no saving). Sign in from the navbar to unlock saved parents.
 
 ---
 
@@ -42,7 +42,7 @@ FairShare gives a quick, transparent estimate of who pays child support and how 
 
 | Role      | Typical Access       | Notes                                                                 |
 | --------- | --------------------- | ---------------------------------------------------------------------|
-| **Guest** | Limited preview       | Run calculations; no saving or admin. (`Continue as Guest` on login) |
+| **Guest** | Default identity      | Every visitor until they sign in; run calculations and export, no saving or admin. |
 | **User**  | Normal app usage      | Create and run scenarios, save parent profiles.                      |
 | **Admin** | Full administration   | Manage users, roles, and access the users dashboard.                 |
 

--- a/docs/adr/0002-guest-first-landing.md
+++ b/docs/adr/0002-guest-first-landing.md
@@ -1,0 +1,33 @@
+# ADR 0002 — Guest-first landing
+
+**Status:** Accepted — 2026-08-18
+
+## Context
+
+FairShare has a full Identity stack — accounts, roles, an admin console — but accounts are admin-provisioned. On a publicly hosted instance nearly every visitor is, and will remain, a guest. The app nevertheless landed everyone on the login screen: an anonymous visitor hitting `/` failed `[Authorize]`, was redirected to `/login`, and had to find the "Continue as Guest" link to reach the calculator.
+
+That wall gated nothing. Guest access was one click away for anyone, so the login-first flow added friction without adding access control — and the majority audience (a parent who wants a CS-42 number) paid that friction on every visit.
+
+## Decision
+
+Guest is the **default identity**; the state picker is the effective landing page.
+
+1. On startup, when re-hydrating the session from the refresh cookie fails, the Web app silently issues itself a guest session (`POST /auth/guest`) before first render. The login redirect remains only as a fallback for when the API is unreachable.
+2. The login page is purely an **upgrade** to an account: "Continue as Guest" is removed (visitors already are guests) and replaced with a back link.
+3. The navbar keeps the muted "Guest" badge (what you are) and adds a "Sign in" link with a `returnUrl` (what you can do about it).
+4. Logging out of an account drops back to a fresh guest session on the state picker, not the login page.
+5. `[Authorize]` stays on the public pages as defense in depth; the API remains the real gate (`NotGuest` / `AdminOnly` policies are unchanged).
+
+Shipped as **3.0.0**: the default deployment posture changes from login-first to public-calculator, and a user-facing affordance ("Continue as Guest") is removed — operators deserve a major-version flag on that even though no API contract breaks.
+
+## Consequences
+
+- Every anonymous visit (crawlers included) mints a guest refresh-token row. Cost is bounded: the `auth` rate limiter caps the mint rate per IP and `RefreshTokenCleanupService` purges expired rows every 6 hours.
+- Signing in mid-form remounts the calculator and loses typed figures. Accepted: the sign-in prompts sit before data entry in the natural flow. If it stings, state-stashing is its own issue.
+- The login screen can no longer be mistaken for an access barrier. An operator who wants a truly private instance must put real authentication in front (it never actually had one — guest access was self-service).
+
+## Alternatives considered
+
+- **Lazy guest issuance** (mint only on the first API-needing action). Buys nothing: the landing page's state list is itself an authorized API call, so "first action" is page load.
+- **Keep login-first with a bigger "Continue as Guest" button.** Still charges the majority audience a click and a decision for zero security.
+- **Anonymous API access for calculations.** Would drop the session model entirely for guests; rejected because rate limiting, activity middleware, and the single bearer-token code path are worth keeping uniform.

--- a/src/FairShare.Web/Auth/AuthApiClient.cs
+++ b/src/FairShare.Web/Auth/AuthApiClient.cs
@@ -77,8 +77,23 @@ public class AuthApiClient(HttpClient http, ITokenStore tokenStore, JwtAuthentic
     public Task<AuthResult> RegisterAsync(string userName, string password) =>
         SendAuthRequestAsync("api/v1/auth/register", new RegisterRequest { UserName = userName, Password = password });
 
-    public Task<AuthResult> ContinueAsGuestAsync() =>
-        SendAuthRequestAsync("api/v1/auth/guest", body: null);
+    /// <summary>
+    /// Attempts to start a guest session, e.g. for a visitor with no account session
+    /// (guest-first landing) or after logging out of an account. Never throws; returns
+    /// false when the API is unreachable, leaving the visitor anonymous.
+    /// </summary>
+    public async Task<bool> TryStartGuestSessionAsync()
+    {
+        try
+        {
+            AuthResult result = await SendAuthRequestAsync("api/v1/auth/guest", body: null);
+            return result.Success;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+    }
 
     /// <summary>
     /// Attempts a silent refresh using the HttpOnly refresh cookie, e.g. to re-hydrate the

--- a/src/FairShare.Web/Layout/NavMenu.razor
+++ b/src/FairShare.Web/Layout/NavMenu.razor
@@ -38,21 +38,29 @@
                     <Authorized>
                         @if (context.User.HasClaim("guest", "true"))
                         {
+                            @* Guests are the default identity: the badge names the state,
+                               the link is the way out of it. Logout would be meaningless. *@
                             <li class="nav-item">
-                                <span class="nav-link text-muted" title="Guest mode: limited functionality">
+                                <span class="nav-link text-muted" title="Guest mode: calculations and export only; sign in to save data">
                                     <small>Guest</small>
                                 </span>
                             </li>
+                            <li class="nav-item">
+                                <NavLink class="nav-link" href="@SignInHref">Sign in</NavLink>
+                            </li>
                         }
-                        <li class="nav-item">
-                            <button class="btn btn-link nav-link" @onclick="LogoutAsync">
-                                Logout
-                            </button>
-                        </li>
+                        else
+                        {
+                            <li class="nav-item">
+                                <button class="btn btn-link nav-link" @onclick="LogoutAsync">
+                                    Logout
+                                </button>
+                            </li>
+                        }
                     </Authorized>
                     <NotAuthorized>
                         <li class="nav-item">
-                            <NavLink class="nav-link" href="login">Login</NavLink>
+                            <NavLink class="nav-link" href="login">Sign in</NavLink>
                         </li>
                     </NotAuthorized>
                 </AuthorizeView>
@@ -69,10 +77,27 @@
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e) => StateHasChanged();
 
+    // Signing in from anywhere returns to that page afterwards; the login page itself
+    // gets no returnUrl so a completed sign-in lands on the state picker instead.
+    private string SignInHref
+    {
+        get
+        {
+            string relative = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+
+            return relative.StartsWith("/login", StringComparison.OrdinalIgnoreCase)
+                ? "login"
+                : $"login?returnUrl={Uri.EscapeDataString(relative)}";
+        }
+    }
+
     private async Task LogoutAsync()
     {
+        // Guest-first landing: leaving an account drops back to the default guest
+        // identity rather than stranding the visitor on the login page.
         await AuthApi.LogoutAsync();
-        NavigationManager.NavigateTo("/login");
+        await AuthApi.TryStartGuestSessionAsync();
+        NavigationManager.NavigateTo("/");
     }
 
     public void Dispose()

--- a/src/FairShare.Web/Pages/Login.razor
+++ b/src/FairShare.Web/Pages/Login.razor
@@ -39,7 +39,7 @@
         {
             <span></span>
         }
-        <button class="btn btn-link p-0" @onclick="ContinueAsGuestAsync" disabled="@_busy">Continue as Guest</button>
+        <a href="@SafeReturnTarget">&larr; Back</a>
     </div>
 </div>
 
@@ -73,32 +73,18 @@
             return;
         }
 
-        string target = !string.IsNullOrWhiteSpace(ReturnUrl) &&
-            ReturnUrl.StartsWith("/", StringComparison.Ordinal) &&
-            !ReturnUrl.StartsWith("//", StringComparison.Ordinal)
-                ? ReturnUrl
-                : "/";
-
-        Navigation.NavigateTo(target);
+        Navigation.NavigateTo(SafeReturnTarget);
     }
 
-    private async Task ContinueAsGuestAsync()
-    {
-        _busy = true;
-        _error = null;
-
-        var result = await AuthApi.ContinueAsGuestAsync();
-
-        _busy = false;
-
-        if (!result.Success)
-        {
-            _error = result.Error;
-            return;
-        }
-
-        Navigation.NavigateTo("/");
-    }
+    // Visitors arrive here already holding a guest session (guest-first landing), so the
+    // way out without signing in is simply going back. Only same-origin absolute paths
+    // are honored to keep the redirect target un-spoofable.
+    private string SafeReturnTarget =>
+        !string.IsNullOrWhiteSpace(ReturnUrl) &&
+        ReturnUrl.StartsWith("/", StringComparison.Ordinal) &&
+        !ReturnUrl.StartsWith("//", StringComparison.Ordinal)
+            ? ReturnUrl
+            : "/";
 
     private class LoginModel
     {

--- a/src/FairShare.Web/Program.cs
+++ b/src/FairShare.Web/Program.cs
@@ -41,6 +41,14 @@ WebAssemblyHost host = builder.Build();
 
 // The access token lives only in memory, so a page reload loses it. Re-hydrate it from
 // the HttpOnly refresh cookie before first render so an active session survives reloads.
-await host.Services.GetRequiredService<AuthApiClient>().TryRefreshAsync();
+// Visitors with no session at all get a guest one so the calculator is usable immediately
+// (guest-first landing, ADR 0002); if the API is unreachable they stay anonymous and the
+// router falls back to the login redirect.
+AuthApiClient authApi = host.Services.GetRequiredService<AuthApiClient>();
+
+if (!await authApi.TryRefreshAsync())
+{
+    await authApi.TryStartGuestSessionAsync();
+}
 
 await host.RunAsync();

--- a/src/FairShare.Web/README.md
+++ b/src/FairShare.Web/README.md
@@ -7,7 +7,7 @@ Standalone Blazor WebAssembly SPA. Compiled to static WASM assets and served by 
 - `Auth/` — the client-side auth machinery:
   - `AuthApiClient` — typed wrapper for the `/api/v1/auth/*` endpoints; caches the server's auth-config flags (fail-closed).
   - `AuthTokenHandler` — `DelegatingHandler` that attaches the bearer token and, on 401, performs one serialized silent refresh + retry (skipped for anonymous auth endpoints so a failed login can't "succeed" via refresh).
-  - `InMemoryTokenStore` — the access token lives in memory only (XSS hardening); page reloads re-hydrate via the HttpOnly refresh cookie (`Program.cs` calls `TryRefreshAsync()` before first render).
+  - `InMemoryTokenStore` — the access token lives in memory only (XSS hardening); page reloads re-hydrate via the HttpOnly refresh cookie (`Program.cs` calls `TryRefreshAsync()` before first render, falling back to a fresh guest session — guest-first landing, ADR 0002).
   - `JwtAuthenticationStateProvider` / `JwtParser` — claims → `AuthenticationState`; policies `AdminOnly` and `NotGuest` mirror the API's.
 - `Pages/` — `Home` (state picker), `Calculator`, `Profiles` (saved parents), `Login`/`Register` (registration UI hides itself when the server reports self-registration disabled), `ChangePassword`, `Admin/*` (user management).
   - The two Primary Custody switches are mutually exclusive when clicked (flipping one flips the other to the opposite); loading a saved profile or clearing a card only affects that card. Interop/HTTP failures during Calculate/Export surface as inline messages, not Blazor's fatal banner (which is styled with Bootstrap's theme-aware warning tokens in `app.css`).


### PR DESCRIPTION
Closes #93

## What

Makes guest the default identity and the state picker the effective landing page:

- **`Program.cs`**: when refresh-cookie hydration finds no session, silently issue a guest session (`POST /auth/guest`) before first render. `RedirectToLogin` remains only as an API-unreachable fallback.
- **`AuthApiClient`**: `ContinueAsGuestAsync` becomes `TryStartGuestSessionAsync` — never throws, mirrors `TryRefreshAsync` semantics.
- **`Login.razor`**: now purely an account upgrade — "Continue as Guest" removed (visitors already are guests), replaced with a back link honoring the sanitized `returnUrl`.
- **`NavMenu.razor`**: guests see the "Guest" badge (state) plus a "Sign in" link with `returnUrl` (action) and no meaningless Logout; account users' Logout now drops back to a fresh guest session on the state picker instead of stranding them on `/login`.
- **Docs**: `docs/adr/0002-guest-first-landing.md` (trade-offs + why this is 3.0.0), `CONTEXT.md` Access vocabulary (Guest = the default identity), README updates.

## Why

Accounts are admin-provisioned, so on a public instance nearly every visitor is and stays a guest — yet the app landed everyone on a login wall that gated nothing (guest access was one click away regardless).

## Notes

- No API changes. `[Authorize]` stays on public pages as defense in depth; `NotGuest`/`AdminOnly` unchanged.
- Anonymous visits mint guest refresh-token rows; bounded by the `auth` rate limiter and the 6-hour `RefreshTokenCleanupService` purge (see ADR).
- 147/147 tests pass.

BREAKING CHANGE: the default deployment posture changes from login-first to public calculator, and the login page's "Continue as Guest" affordance is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
