### PR TITLE
feat: distinct party, results, and action styling with form a11y

### DIFF
--- a/src/FairShare.Web/Components/ParentCard.razor
+++ b/src/FairShare.Web/Components/ParentCard.razor
@@ -3,10 +3,10 @@
 @inject NavigationManager Navigation
 
 <div class="col-12 col-lg-6">
-    <div class="card h-100 shadow-sm">
+    <div class="card h-100 shadow-sm fs-party-card @PartyClass">
         <div class="card-header text-center d-flex flex-column gap-2">
             <div class="d-flex justify-content-between align-items-center">
-                <strong>@Title</strong>
+                <span class="badge fs-party-badge">@Title</span>
                 @if (ShowPrimary)
                 {
                     <div class="form-check form-switch m-0">
@@ -131,6 +131,10 @@
 
     private string SignInHref =>
         $"login?returnUrl={Uri.EscapeDataString("/" + Navigation.ToBaseRelativePath(Navigation.Uri))}";
+
+    // Prefix is the party identity ("Plaintiff"/"Defendant"); the class picks that
+    // party's accent tokens in app.css.
+    private string PartyClass => $"fs-party-{Prefix.ToLowerInvariant()}";
 
     private async Task OnPrimaryChanged(ChangeEventArgs e)
     {

--- a/src/FairShare.Web/Pages/Calculator.razor
+++ b/src/FairShare.Web/Pages/Calculator.razor
@@ -46,7 +46,18 @@
     <div class="row g-3 mb-4 justify-content-center">
         <div class="col-12 col-sm-5 col-lg-3 text-center">
             <label class="form-label" for="NumberOfChildren">Number of Children</label>
-            <input type="number" id="NumberOfChildren" @bind="numberOfChildren" class="form-control" />
+            @* The schedule covers exactly 1-6 children (BcsoLookup.MinChildren/MaxChildren);
+               the old free number input defaulted to 0 and let 7+ through, both only to be
+               rejected at Calculate time. *@
+            <select id="NumberOfChildren" @bind="numberOfChildren" class="form-select" aria-describedby="NumberOfChildrenHelp">
+                @for (int children = 1; children <= 6; children++)
+                {
+                    <option value="@children">@children</option>
+                }
+            </select>
+            <div id="NumberOfChildrenHelp" class="form-text">
+                The schedule covers up to 6 children; beyond that, support is at the court's discretion.
+            </div>
         </div>
     </div>
 
@@ -81,18 +92,32 @@
 
     <div class="mt-3 d-flex gap-2">
         <button class="btn btn-primary" @onclick="() => CalculateAsync()" disabled="@calculating">Calculate</button>
-        <button class="btn btn-outline-secondary" @onclick="Reset">Reset</button>
-        <button class="btn btn-outline-primary ms-auto"
+        <button class="btn btn-outline-danger" @onclick="ResetAsync">Reset</button>
+        <button class="btn btn-outline-success ms-auto d-inline-flex align-items-center gap-2"
                 @onclick="ExportAsync"
                 disabled="@(exporting || !CanExport)"
-                title="Download the official worksheet with these figures filled in">
-            @(exporting ? "Preparing..." : "Export to Excel")
+                aria-label="Export to Excel"
+                title="Download the official Excel worksheet with these figures filled in">
+            @if (exporting)
+            {
+                <span>Preparing...</span>
+            }
+            else
+            {
+                @* Inline spreadsheet glyph (currentColor follows the button/theme); one icon
+                   does not justify vendoring an icon library into the WASM payload. *@
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"
+                     fill="currentColor" fill-rule="evenodd" aria-hidden="true" focusable="false">
+                    <path d="M2.5 2h11a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5zM3 3v2h10V3H3zm0 3v3h4.5V6H3zm5.5 0v3H13V6H8.5zM3 10v3h4.5v-3H3zm5.5 0v3H13v-3H8.5z"/>
+                </svg>
+                <span>Export</span>
+            }
         </button>
     </div>
 
     @if (errors.Any())
     {
-        <div class="mt-3">
+        <div class="mt-3" role="alert">
             <ul class="text-danger">
                 @foreach (var error in errors)
                 {
@@ -103,9 +128,11 @@
     }
 
     <div class="mt-5">
-        <div class="card shadow-sm">
+        <div class="card shadow-sm fs-results-card">
             <div class="card-header text-center"><strong>Results</strong></div>
-            <div class="card-body">
+            @* aria-live so screen-reader users hear the outcome (or the failure) they asked
+               for - results used to appear silently. *@
+            <div class="card-body" aria-live="polite">
                 @if (submitted && result is not null && result.Success)
                 {
                     <p class="fw-bold text-center mb-0">@ResultSentence(result)</p>
@@ -127,8 +154,8 @@
                                 <tbody>
                                     @foreach (var line in result.Lines)
                                     {
-                                        <tr class="@(IsFinalLine(line) ? "table-primary fw-bold" : "")">
-                                            <td>@line.Number</td>
+                                        <tr class="@(IsFinalLine(line) ? "fs-row-recommended-order fw-bold" : "")">
+                                            <th scope="row" class="fw-normal text-start">@line.Number</th>
                                             <td>@line.Label</td>
                                             <td class="text-end">@FormatCell(line, line.Plaintiff)</td>
                                             <td class="text-end">@FormatCell(line, line.Defendant)</td>
@@ -168,7 +195,9 @@
 
     [CascadingParameter] private Task<AuthenticationState>? AuthStateTask { get; set; }
 
-    private int numberOfChildren;
+    // 1 is the floor of the schedule's 1-6 range and the reason anyone opens the app;
+    // Reset returns here too (0 was an invalid state the dropdown cannot even express).
+    private int numberOfChildren = 1;
     private readonly ParentDataDto plaintiff = new();
     private readonly ParentDataDto defendant = new();
     private string? plaintiffName;
@@ -472,9 +501,16 @@
         HasPrimaryCustody = data.HasPrimaryCustody
     };
 
-    private void Reset()
+    private async Task ResetAsync()
     {
-        numberOfChildren = 0;
+        // Reset is destructive with no undo, so confirm - but only when there is
+        // something to lose, keeping the empty-form case one click.
+        if (HasEnteredData && !await JS.InvokeAsync<bool>("confirm", "Clear all entered figures and results?"))
+        {
+            return;
+        }
+
+        numberOfChildren = 1;
         plaintiff.ApplyFrom(new ParentDataDto());
         defendant.ApplyFrom(new ParentDataDto());
         plaintiffName = null;
@@ -484,6 +520,22 @@
         ClearResult();
         errors.Clear();
     }
+
+    private bool HasEnteredData =>
+        numberOfChildren != 1
+        || HasFigures(plaintiff)
+        || HasFigures(defendant)
+        || !string.IsNullOrWhiteSpace(plaintiffName)
+        || !string.IsNullOrWhiteSpace(defendantName)
+        || submitted;
+
+    private static bool HasFigures(ParentDataDto parent) =>
+        parent.MonthlyGrossIncome != 0
+        || parent.PreexistingChildSupport != 0
+        || parent.PreexistingAlimony != 0
+        || parent.WorkRelatedChildcareCosts != 0
+        || parent.HealthcareCoverageCosts != 0
+        || parent.HasPrimaryCustody;
 
     private void ClearResult()
     {

--- a/src/FairShare.Web/wwwroot/app.css
+++ b/src/FairShare.Web/wwwroot/app.css
@@ -85,3 +85,82 @@ h1:focus {
         right: 0.75rem;
         top: 0.5rem;
     }
+
+/* FairShare accent tokens. Parties get cool hues deliberately disjoint from the action
+   palette (blue Calculate, red Reset, green Export); the results card gets the page's one
+   warm accent so the answer draws the eye. Each emphasis/background pair keeps WCAG AA
+   text contrast in its theme - the dark values are re-tuned, not auto-derived. theme-init.js
+   always resolves "auto" and stamps data-bs-theme, so the dark block needs no media query. */
+:root {
+    --fs-plaintiff-border: #0aa2c0;
+    --fs-plaintiff-bg-subtle: #d2f4f8;
+    --fs-plaintiff-emphasis: #0a5866;
+    --fs-defendant-border: #8540f5;
+    --fs-defendant-bg-subtle: #e8dcfd;
+    --fs-defendant-emphasis: #4c2889;
+    --fs-results-border: #997404;
+    --fs-results-bg-subtle: #fff3cd;
+    --fs-results-emphasis: #664d03;
+}
+
+[data-bs-theme="dark"] {
+    --fs-plaintiff-border: #087990;
+    --fs-plaintiff-bg-subtle: #04333c;
+    --fs-plaintiff-emphasis: #7ae1f5;
+    --fs-defendant-border: #8f5cf7;
+    --fs-defendant-bg-subtle: #2c1a52;
+    --fs-defendant-emphasis: #c5a1fc;
+    --fs-results-border: #997404;
+    --fs-results-bg-subtle: #332701;
+    --fs-results-emphasis: #ffda6a;
+}
+
+/* Party cards: color is never the only distinguisher - the tinted edge pairs with the
+   labeled badge in each header (WCAG 1.4.1). */
+.fs-party-card {
+    border-left-style: solid;
+    border-left-width: 4px;
+}
+
+.fs-party-plaintiff {
+    border-left-color: var(--fs-plaintiff-border);
+}
+
+.fs-party-defendant {
+    border-left-color: var(--fs-defendant-border);
+}
+
+.fs-party-badge {
+    font-size: 0.875rem;
+}
+
+.fs-party-plaintiff .fs-party-badge {
+    background-color: var(--fs-plaintiff-bg-subtle);
+    border: 1px solid var(--fs-plaintiff-border);
+    color: var(--fs-plaintiff-emphasis);
+}
+
+.fs-party-defendant .fs-party-badge {
+    background-color: var(--fs-defendant-bg-subtle);
+    border: 1px solid var(--fs-defendant-border);
+    color: var(--fs-defendant-emphasis);
+}
+
+/* Results card: the gold accent also carries the worksheet's recommended-order row
+   (previously .table-primary, which read as if it belonged to the blue button). */
+.fs-results-card {
+    border-color: var(--fs-results-border);
+}
+
+.fs-results-card > .card-header {
+    background-color: var(--fs-results-bg-subtle);
+    border-bottom-color: var(--fs-results-border);
+    color: var(--fs-results-emphasis);
+}
+
+/* -state beats the striped -type variables in Bootstrap 5.3's cell color resolution,
+   so the highlight survives table-striped. */
+.worksheet-table > tbody > .fs-row-recommended-order {
+    --bs-table-bg-state: var(--fs-results-bg-subtle);
+    --bs-table-color-state: var(--fs-results-emphasis);
+}


### PR DESCRIPTION
Closes #95

## What

### Accent token layer (`app.css`)

`--fs-plaintiff-*` (teal), `--fs-defendant-*` (violet), `--fs-results-*` (gold) — border/bg-subtle/emphasis triples, re-tuned (not auto-derived) under `[data-bs-theme="dark"]`. Every emphasis/background pair and border/background pair was script-verified against WCAG AA (4.5:1 text, 3:1 non-text) in both themes. Parties get cool hues deliberately disjoint from the action palette; the results card gets the page's one warm accent.

### Party cards (`ParentCard.razor`)

Tinted 4px left edge + a labeled badge in each header — color is never the only distinguisher (WCAG 1.4.1); the badge text carries the party name.

### Results card (`Calculator.razor`)

Gold border + tinted header, and the worksheet's recommended-order row moves from `table-primary` (which read as if it belonged to the blue button) onto the results token via Bootstrap 5.3's `--bs-table-*-state` variables, so the highlight survives `table-striped`.

### Buttons

- Calculate: unchanged solid blue.
- Reset: `btn-outline-danger` (destructive signal without competing with Calculate) + a confirm dialog **only when the form has entered data** — an empty form resets in one click.
- Export: `btn-outline-success` with an inline spreadsheet SVG (`currentColor`, works in both themes; one icon does not justify vendoring an icon library into the WASM payload) + visible "Export" text; `aria-label="Export to Excel"` keeps the full name for screen readers (visible text contained, per WCAG 2.5.3).

### Number of Children

Free number input → `<select>` of 1–6 (the schedule's range, `BcsoLookup.MinChildren`/`MaxChildren`), default **1** — the old input defaulted to 0 and accepted 7+, both only to be rejected at Calculate time. Reset now lands on 1. Muted helper text explains the 6-child schedule limit.

### Accessibility riders

- `aria-live="polite"` on the results card body — results and calculation failures used to appear silently to screen readers.
- `role="alert"` on the page-level error block.
- The worksheet's Line column cells are now `<th scope="row">`.

## Notes

- Pure Web project (CSS/markup/component) change; no API or Domain changes.
- 147/147 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
