### PR TITLE
feat: admin observability — persistent logs, audit trail, first-party analytics

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,7 +41,18 @@ The ubiquitous language of the FairShare domain: child-support worksheets as the
 | Term | Meaning |
 |---|---|
 | **Guest** | The default identity — anyone who has not signed in. A guest can calculate and export, never persist. |
-| **User / Admin** | Admin-provisioned accounts. A user additionally saves parent profiles; an admin additionally manages accounts. |
+| **User / Admin** | Signed-in accounts — a user signs in with an outside identity provider (or is admin-provisioned); an account is free. A user additionally saves parent profiles; an admin additionally manages accounts. |
+| **Guest work** | A guest's in-progress calculation. It lives only in their browser and is never stored unless they sign in and choose to save it. |
+| **Gated feature** | A capability reserved for users (e.g. saving a profile). The moment a guest reaches one is the invitation to sign in. |
+
+## Observability vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Daily visitor** | A person counted at most once per UTC day by an anonymous key that cannot connect them across days. Never call this a "unique visitor" or "returning visitor" — FairShare cannot know either. |
+| **Audit event** | A record that an account did something accountability cares about (signed in, was created, changed, or deleted). Kept longer than diagnostic logs; outlives the account it names until it expires. |
+| **Diagnostic log** | A record of what the system did, kept briefly for troubleshooting. Never contains case content, names, or money amounts. |
+| **Verbose mode** | A temporary admin-switched state in which diagnostic logs capture extra detail. It always turns itself back off. |
 
 ## Fidelity vocabulary
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,12 @@ services:
       retries: 6
       start_period: 15s
     restart: unless-stopped
+    # Cap stdout logs: durable logs now live in SQLite (admin > Logs), stdout is a fallback.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   web:
     build:
@@ -49,6 +55,11 @@ services:
       timeout: 3s
       retries: 6
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   fairshare-data:

--- a/docs/API.md
+++ b/docs/API.md
@@ -184,6 +184,39 @@ Saved parent profiles. **Ownership-scoped**: every query filters by the authenti
 
 ---
 
+## Analytics beacon — `/api/v1/analytics` (anonymous)
+
+First-party, cookieless capture endpoints for the SPA (see `docs/adr/0003-first-party-cookieless-analytics.md`). Both return **204 regardless of whether anything was recorded** — the server applies every rule (DNT/`Sec-GPC` opt-out, bot user-agents, excluded paths, admin's own browsing) and callers cannot observe the outcome. No cookies, no identifiers: visitors are counted by a daily-rotating HMAC that cannot link two days together.
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/analytics/page-views` | `{ "path": "/states/al/cs42", "referrer": "https://..." }`. `referrer` only on the SPA's first load. |
+| POST | `/analytics/events` | `{ "name": "gated-hit", "target": "profiles" }`. Only whitelisted client event names are accepted (`gated-hit`); server-observed events (calculations) are recorded server-side and cannot be posted. Targets are restricted to short kebab-case tokens. |
+
+## Admin stats — `/api/v1/admin/stats` (Bearer + Admin role)
+
+`days` selects the period ending today (`7`, `30`, ...); omit or `0` for all time. Completed days come from nightly rollups; today is computed live.
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/admin/stats/summary?days=30` | Tiles: `{ pageViews, dailyVisitors, calculationsCompleted, gatedHits, donateClicks, firstDay }`. |
+| GET | `/admin/stats/pages?days=&page=&pageSize=&sort=views\|visitors\|path&desc=` | Top pages, paged: `{ items: [{ path, views, visitors }], page, pageSize, totalCount }`. |
+| GET | `/admin/stats/referrers?days=` | Top 10 external referrer hosts: `[{ referrerHost, views }]`. |
+| GET | `/admin/stats/events?days=` | Event counts: `[{ name, target, count }]`, descending. |
+
+## Admin logs — `/api/v1/admin/logs` (Bearer + Admin role)
+
+Diagnostic logs persist 30 days; audit events ~1 year (and survive account deletion). Verbose mode raises capture to Debug and **always turns itself back off** (~4 h or process restart); toggling it is itself an audit event.
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/admin/logs?level=&search=&page=&pageSize=` | Diagnostic logs, newest first. `level` = minimum (`Debug`/`Information`/`Warning`/`Error`); `search` matches message and category. |
+| GET | `/admin/logs/audit?page=&pageSize=` | Audit events, newest first: `{ items: [{ occurredAtUtc, actorName, action, target, detail }], ... }`. |
+| GET | `/admin/logs/verbose` | `{ "enabled": bool, "untilUtc": "..." }`. |
+| PUT | `/admin/logs/verbose` | `{ "enabled": true\|false }` → the new status. |
+
+---
+
 ## Misc
 
 | Method | Path | Auth | Description |

--- a/docs/adr/0003-first-party-cookieless-analytics.md
+++ b/docs/adr/0003-first-party-cookieless-analytics.md
@@ -10,7 +10,7 @@ ADR 0002 made a bet — guest-first landing with gated persistence — and nothi
 
 Analytics are **first-party, cookieless, and content-free**, stored in the app's own SQLite database and visible only at `/admin/stats`.
 
-1. **Capture**: API-backed actions record events server-side. Page views come from a tiny first-party beacon — the SPA router fires `POST /api/v1/analytics/pageview` on navigation. `DNT: 1` and `Sec-GPC: 1` suppress recording, checked on both client and server. No cookies, no pixels, no third-party script.
+1. **Capture**: API-backed actions record events server-side. Page views come from a tiny first-party beacon — the SPA router fires `POST /api/v1/analytics/page-views` on navigation. `DNT: 1` and `Sec-GPC: 1` suppress recording, checked on both client and server. No cookies, no pixels, no third-party script.
 2. **Visitors**: counted as **Daily visitors** — `HMAC(per-install secret, UTC date + IP + UA)`. The date inside the hash makes cross-day linkage deliberately impossible; IP and user-agent are hash inputs only, never stored. Bot UAs (and empty UAs) are excluded; admin browsing is excluded.
 3. **Events carry a name and a coarse target, never content.** v1 taxonomy: `calculation-started` / `calculation-completed` (target: form key), `gated-hit` (target: which gate), `donate-click` (via a first-party redirect); the accounts effort adds `sign-in`, `account-created`, `account-deleted`, `guest-work-imported`. No money amounts, no child counts, no case data — ever, including in targets.
 4. **Retention**: a nightly rollup service aggregates raw rows into daily stat tables and deletes raw rows after 90 days; aggregates are kept; "today" is computed live from raw rows.

--- a/docs/adr/0003-first-party-cookieless-analytics.md
+++ b/docs/adr/0003-first-party-cookieless-analytics.md
@@ -1,0 +1,32 @@
+# ADR 0003 — First-party cookieless analytics on a WASM SPA
+
+**Status:** Accepted — 2026-08-20
+
+## Context
+
+ADR 0002 made a bet — guest-first landing with gated persistence — and nothing measures whether it is paying off. The owner wants engagement and conversion-intent insight (are visitors calculating, finishing, hitting the gates?) plus basic reach. FairShare handles child-support financials, so the analytics must be beyond reproach: the site's core promise is privacy, and the measurement must not undercut it. Portfolio's first-party cookieless analytics (its ADR 0001) is the proven in-house precedent, but Portfolio is Blazor Server — its capture middleware sees every page request. FairShare is a standalone WASM SPA served by nginx: after first load, route changes never touch the API.
+
+## Decision
+
+Analytics are **first-party, cookieless, and content-free**, stored in the app's own SQLite database and visible only at `/admin/stats`.
+
+1. **Capture**: API-backed actions record events server-side. Page views come from a tiny first-party beacon — the SPA router fires `POST /api/v1/analytics/pageview` on navigation. `DNT: 1` and `Sec-GPC: 1` suppress recording, checked on both client and server. No cookies, no pixels, no third-party script.
+2. **Visitors**: counted as **Daily visitors** — `HMAC(per-install secret, UTC date + IP + UA)`. The date inside the hash makes cross-day linkage deliberately impossible; IP and user-agent are hash inputs only, never stored. Bot UAs (and empty UAs) are excluded; admin browsing is excluded.
+3. **Events carry a name and a coarse target, never content.** v1 taxonomy: `calculation-started` / `calculation-completed` (target: form key), `gated-hit` (target: which gate), `donate-click` (via a first-party redirect); the accounts effort adds `sign-in`, `account-created`, `account-deleted`, `guest-work-imported`. No money amounts, no child counts, no case data — ever, including in targets.
+4. **Retention**: a nightly rollup service aggregates raw rows into daily stat tables and deletes raw rows after 90 days; aggregates are kept; "today" is computed live from raw rows.
+5. **Related decision — logs share the philosophy**: diagnostic logs and audit events are captured by a small hand-rolled `ILoggerProvider` batching into SQLite (no Serilog), so the structural no-sensitive-data wall lives in code we own. Diagnostic logs keep 30 days; audit events keep ~1 year and outlive the accounts they name. Verbose mode is a runtime switch that auto-reverts (~4 h) and is itself an audit event.
+
+## Consequences
+
+- FairShare cannot borrow Portfolio's "nothing runs in your browser" claim — the beacon is client code. The truthful claim, stated on the privacy page: *our own code only, no third parties, no cookies, nothing identifying stored*.
+- Cross-day uniques, retention curves, and "returning visitors" are impossible **by design**; the glossary bans those terms.
+- Ad-blockers may eat the beacon; undercounting page views is accepted. API-backed events are unaffected.
+- Guest refresh-token rows (ADR 0002's accidental, bot-polluted visit proxy) stop being anyone's analytics.
+- Account deletion (ADR 0004) does not touch analytics — there is nothing linkable to delete — but audit events survive until their own retention expires, disclosed on the privacy page.
+
+## Alternatives considered
+
+- **Hosted analytics (Plausible/Umami container + JS snippet).** Same rejection as Portfolio's: an extra service to run, a script for ad-blockers to eat, and the privacy guarantee living in a vendor's defaults instead of our own code.
+- **Anonymous cookie ID.** Accurate cross-day uniques, but a client-side identifier drags a child-support site into consent-banner territory. Rejected outright.
+- **Scraping nginx access logs.** The static server never sees SPA route changes, and it would mean retaining raw IPs — the opposite of the point.
+- **Serilog + SQLite sink for the log pipeline.** Industry-standard, but two new dependencies (one weakly maintained) for 17 call sites, and redaction guarantees are easiest to prove in a sink we wrote.

--- a/docs/adr/0004-external-oauth-only-public-accounts.md
+++ b/docs/adr/0004-external-oauth-only-public-accounts.md
@@ -1,0 +1,36 @@
+# ADR 0004 — External-OAuth-only public accounts
+
+**Status:** Accepted — 2026-08-20
+
+## Context
+
+ADR 0002 left FairShare with no self-serve sign-up: accounts are admin-provisioned, so the gated features have no public conversion path. Opening sign-up on a site holding child-support financials makes FairShare a credential custodian — and local passwords on this data would demand reset email, 2FA, lockout policy, and breach posture, all operated by one person. The owner's stated bar: the user's sensitive information must be as private as possible, and that must be *visibly* true.
+
+## Decision
+
+Public accounts are **free and external-OAuth-only**; FairShare never holds a public user's password.
+
+1. **Google is the only provider at launch** (working code ports from Portfolio). Microsoft can be added on real demand (free); Apple only if demand ever justifies the $99/yr developer program — iPhone users overwhelmingly have Google accounts anyway. Facebook: never, on privacy optics alone.
+2. **We store only the Google subject ID and email.** Display name defaults to the email's local part and is user-editable. Nothing else Google offers (name, photo, locale) is kept.
+3. **The local password form survives only for admin-provisioned accounts**, demoted behind an "Administrator / legacy sign-in" link; the Google button is the sign-in experience. The existing self-serve local registration (`/register`, `POST /auth/register`, gated behind `Auth:AllowSelfRegistration` — default off, and off in production) is **retired**: page and endpoint removed rather than left as a dormant password door.
+4. **"Remember this device" is an explicit opt-in checkbox**, default unchecked: unchecked issues a session-only cookie, checked issues the 30-day rotating refresh cookie. Shared family computers — possibly shared with the other parent in the case — are the default assumption.
+5. **Guest work carries over on the user's say-so.** In-progress work is stashed across the OAuth redirect and an explicit prompt offers to save it — on *every* sign-in with unsaved work, not just the first. The uniform rule, and the headline privacy claim: *nothing you type is stored unless you choose to save it; nothing is lost without asking*.
+6. **Self-service hard delete** ("Delete my account and all my data") is a launch requirement for public sign-up, not a follow-up.
+7. **TOTP 2FA is required for Admin-role local accounts**; family local accounts stay password-only (they guard only their own data), and public users inherit 2FA from Google.
+
+The account's value proposition is continuity only — your saved profiles, back on any device — pitched in exactly those words, with no roadmap promises.
+
+## Consequences
+
+- No password-reset, credential-2FA, or lockout infrastructure to build, and no password hashes to breach. Google's account security (resets, suspicious-login detection) is inherited for free.
+- A privacy-minded user unwilling to link Google has no way in. Accepted for launch; local passwords are reconsidered only on real user demand (Identity's schema keeps both doors open, so this is reversible).
+- Public sign-in availability is coupled to Google; the admin's local escape hatch is the mitigation.
+- Audit events (ADR 0003) record account lifecycle with the identity as written at the time and outlive deletion until their ~1-year retention expires — disclosed plainly on the privacy page. A hostile account cannot erase its own trail by self-deleting.
+- No IP banning is built: per-IP rate limiting and the existing account-disable flag cover realistic abuse, and residential IP bans punish innocents. Revisit only on evidence.
+
+## Alternatives considered
+
+- **OAuth + optional email/password.** The password apparatus is the single largest chunk of work and risk in the whole accounts effort, built speculatively for users who may not exist. Deferred until asked for.
+- **Migrating admin/family to Google and deleting local login.** Cleaner surface, but couples admin access to Google availability and a personal Google account. The escape hatch stays.
+- **Silent auto-save of guest work at sign-in.** Less friction, but it would make the site's strongest privacy sentence false at the exact moment of conversion.
+- **Unconditional 30-day persistence (status quo).** Quietly assumes every device is private — the one assumption this site must not make.

--- a/src/FairShare.Api/Controllers/AnalyticsController.cs
+++ b/src/FairShare.Api/Controllers/AnalyticsController.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Observability;
+using FairShare.Contracts.Observability;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FairShare.Api.Controllers;
+
+/// <summary>
+/// First-party beacon endpoints (ADR 0003). Anonymous on purpose - guests are the audience -
+/// and covered by the global per-IP rate limiter. Every capture rule (opt-out, bot, admin
+/// exclusion, path/name validation) is applied server-side; the response is 204 regardless,
+/// so callers learn nothing about what was or wasn't recorded.
+/// </summary>
+[ApiController]
+[Route("api/v1/analytics")]
+[AllowAnonymous]
+public class AnalyticsController(IAnalyticsService analytics) : ControllerBase
+{
+    private readonly IAnalyticsService _analytics = analytics;
+
+    [HttpPost("page-views")]
+    public async Task<IActionResult> RecordPageView([FromBody] PageViewRequest request, CancellationToken ct)
+    {
+        await _analytics.RecordPageViewAsync(HttpContext, request.Path, request.Referrer, ct);
+        return NoContent();
+    }
+
+    [HttpPost("events")]
+    public async Task<IActionResult> RecordEvent([FromBody] ClientEventRequest request, CancellationToken ct)
+    {
+        // Whitelist: browsers may only post gated-hit; server-observed events (calculations,
+        // donate clicks) are recorded server-side and cannot be forged from a client.
+        if (AnalyticsRules.TryNormalizeClientEvent(request.Name, request.Target, out string name, out string? target))
+        {
+            await _analytics.RecordEventAsync(HttpContext, name, target, ct);
+        }
+
+        return NoContent();
+    }
+}

--- a/src/FairShare.Api/Controllers/AnalyticsController.cs
+++ b/src/FairShare.Api/Controllers/AnalyticsController.cs
@@ -11,9 +11,10 @@ namespace FairShare.Api.Controllers;
 /// First-party beacon endpoints (ADR 0003). Anonymous on purpose - guests are the audience -
 /// and covered by the global per-IP rate limiter. Every capture rule (opt-out, bot, admin
 /// exclusion, path/name validation) is applied server-side; the response is 204 regardless,
-/// so callers learn nothing about what was or wasn't recorded.
+/// so callers learn nothing about what was or wasn't recorded. Deliberately NOT
+/// [ApiController]: its automatic 400 on model-binding failures would break the 204-always
+/// contract, so malformed bodies bind to null and are simply not recorded.
 /// </summary>
-[ApiController]
 [Route("api/v1/analytics")]
 [AllowAnonymous]
 public class AnalyticsController(IAnalyticsService analytics) : ControllerBase
@@ -21,18 +22,23 @@ public class AnalyticsController(IAnalyticsService analytics) : ControllerBase
     private readonly IAnalyticsService _analytics = analytics;
 
     [HttpPost("page-views")]
-    public async Task<IActionResult> RecordPageView([FromBody] PageViewRequest request, CancellationToken ct)
+    public async Task<IActionResult> RecordPageView([FromBody] PageViewRequest? request, CancellationToken ct)
     {
-        await _analytics.RecordPageViewAsync(HttpContext, request.Path, request.Referrer, ct);
+        if (request is not null)
+        {
+            await _analytics.RecordPageViewAsync(HttpContext, request.Path, request.Referrer, ct);
+        }
+
         return NoContent();
     }
 
     [HttpPost("events")]
-    public async Task<IActionResult> RecordEvent([FromBody] ClientEventRequest request, CancellationToken ct)
+    public async Task<IActionResult> RecordEvent([FromBody] ClientEventRequest? request, CancellationToken ct)
     {
         // Whitelist: browsers may only post gated-hit; server-observed events (calculations,
         // donate clicks) are recorded server-side and cannot be forged from a client.
-        if (AnalyticsRules.TryNormalizeClientEvent(request.Name, request.Target, out string name, out string? target))
+        if (request is not null
+            && AnalyticsRules.TryNormalizeClientEvent(request.Name, request.Target, out string name, out string? target))
         {
             await _analytics.RecordEventAsync(HttpContext, name, target, ct);
         }

--- a/src/FairShare.Api/Controllers/AuthController.cs
+++ b/src/FairShare.Api/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FairShare.Api.Auth;
 using FairShare.Api.Models;
+using FairShare.Api.Observability;
 using FairShare.Contracts.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -21,7 +22,8 @@ public class AuthController(
     UserManager<ApplicationUser> userManager,
     SignInManager<ApplicationUser> signInManager,
     ITokenService tokenService,
-    IOptions<AuthOptions> authOptions) : ControllerBase
+    IOptions<AuthOptions> authOptions,
+    IAuditService audit) : ControllerBase
 {
     private const string RefreshCookieName = "fairshare_refresh";
 
@@ -29,6 +31,7 @@ public class AuthController(
     private readonly SignInManager<ApplicationUser> _signInManager = signInManager;
     private readonly ITokenService _tokenService = tokenService;
     private readonly AuthOptions _authOptions = authOptions.Value;
+    private readonly IAuditService _audit = audit;
 
     [HttpGet("config")]
     [AllowAnonymous]
@@ -65,6 +68,7 @@ public class AuthController(
         }
 
         await _userManager.AddToRoleAsync(user, "User");
+        await _audit.WriteAsync(AuditActions.Registered, target: user.UserName, ct: ct);
 
         return await IssueTokensAsync(user, ct);
     }
@@ -78,6 +82,9 @@ public class AuthController(
 
         if (user is null || user.IsDisabled)
         {
+            // The attempted username is an identifier, not case content; recording it is
+            // what makes credential-stuffing visible in the audit view.
+            await _audit.WriteAsync(AuditActions.LoginFailed, target: request.UserName, detail: user is null ? "unknown user" : "disabled", ct: ct);
             return Unauthorized();
         }
 
@@ -85,9 +92,11 @@ public class AuthController(
 
         if (!signIn.Succeeded)
         {
+            await _audit.WriteAsync(AuditActions.LoginFailed, target: user.UserName, detail: signIn.IsLockedOut ? "locked out" : "bad password", ct: ct);
             return Unauthorized();
         }
 
+        await _audit.WriteAsync(AuditActions.LoginSucceeded, target: user.UserName, ct: ct);
         return await IssueTokensAsync(user, ct);
     }
 
@@ -170,6 +179,7 @@ public class AuthController(
         // Kill every other session, then re-issue for this one so the caller stays
         // signed in while stolen/old refresh tokens die immediately.
         await _tokenService.RevokeAllForUserAsync(user.Id, ct);
+        await _audit.WriteAsync(AuditActions.PasswordChanged, target: user.UserName, ct: ct);
 
         return await IssueTokensAsync(user, ct);
     }

--- a/src/FairShare.Api/Controllers/CalculationsController.cs
+++ b/src/FairShare.Api/Controllers/CalculationsController.cs
@@ -1,4 +1,7 @@
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Observability;
 using FairShare.Api.Services.Export;
 using FairShare.Contracts.Calculation;
 using FairShare.Domain.Helpers;
@@ -12,13 +15,14 @@ namespace FairShare.Api.Controllers;
 [ApiController]
 [Route("api/v1/states/{state}/forms/{form}/calculations")]
 [Authorize]
-public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetExporter exporter) : ControllerBase
+public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetExporter exporter, IAnalyticsService analytics) : ControllerBase
 {
     private readonly IStateGuidelineCatalog _catalog = catalog;
     private readonly IWorksheetExporter _exporter = exporter;
+    private readonly IAnalyticsService _analytics = analytics;
 
     [HttpPost]
-    public ActionResult<CalculationResponse> Calculate(string state, string form, [FromBody] CalculationRequest request)
+    public async Task<ActionResult<CalculationResponse>> Calculate(string state, string form, [FromBody] CalculationRequest request, CancellationToken ct)
     {
         IChildSupportCalculator? calculator = _catalog.GetCalculator(state, form);
 
@@ -27,10 +31,20 @@ public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetEx
             return NotFound(new { message = $"No calculator registered for {state}/{form}." });
         }
 
+        // Engagement telemetry (ADR 0003): the form key is the whole target - never inputs
+        // or results. "started" = a calculation was attempted, "completed" = it succeeded.
+        string eventTarget = $"{state}/{form}".ToLowerInvariant();
+        await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationStarted, eventTarget, ct);
+
         ParentData plaintiff = ToParentData(request.Plaintiff);
         ParentData defendant = ToParentData(request.Defendant);
 
         CalculationResult result = calculator.Calculate(plaintiff, defendant, request.NumberOfChildren);
+
+        if (result.Success)
+        {
+            await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationCompleted, eventTarget, ct);
+        }
 
         return Ok(ToResponse(result));
     }

--- a/src/FairShare.Api/Controllers/LogsController.cs
+++ b/src/FairShare.Api/Controllers/LogsController.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Observability;
+using FairShare.Api.Persistence;
+using FairShare.Contracts.Observability;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Controllers;
+
+[Authorize(Policy = "AdminOnly")]
+[ApiController]
+[Route("api/v1/admin/logs")]
+public class LogsController(FairShareDbContext db, LogLevelSwitch levelSwitch, IAuditService audit) : ControllerBase
+{
+    private readonly FairShareDbContext _db = db;
+    private readonly LogLevelSwitch _levelSwitch = levelSwitch;
+    private readonly IAuditService _audit = audit;
+
+    /// <param name="level">Minimum level to include (name or number); null shows everything captured.</param>
+    /// <param name="search">Case-insensitive substring over message and category.</param>
+    [HttpGet]
+    public async Task<ActionResult<PagedResult<LogEntryRow>>> GetLogs(
+        string? level, string? search, int page = 1, int pageSize = 50, CancellationToken ct = default)
+    {
+        page = page < 1 ? 1 : page;
+        pageSize = pageSize is < 1 or > 200 ? 50 : pageSize;
+
+        IQueryable<LogEntry> query = _db.Logs.AsNoTracking();
+
+        if (TryParseLevel(level, out LogLevel minimum))
+        {
+            int min = (int)minimum;
+            query = query.Where(l => l.Level >= min);
+        }
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            string term = $"%{search.Trim()}%";
+            query = query.Where(l => EF.Functions.Like(l.Message, term) || EF.Functions.Like(l.Category, term));
+        }
+
+        int total = await query.CountAsync(ct);
+
+        List<LogEntryRow> items = await query
+            .OrderByDescending(l => l.OccurredAtUtc)
+            .ThenByDescending(l => l.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(l => new LogEntryRow
+            {
+                Id = l.Id,
+                OccurredAtUtc = l.OccurredAtUtc,
+                Level = ((LogLevel)l.Level).ToString(),
+                Category = l.Category,
+                Message = l.Message,
+                Exception = l.Exception
+            })
+            .ToListAsync(ct);
+
+        return Ok(new PagedResult<LogEntryRow> { Items = items, Page = page, PageSize = pageSize, TotalCount = total });
+    }
+
+    [HttpGet("audit")]
+    public async Task<ActionResult<PagedResult<AuditEventRow>>> GetAuditEvents(
+        int page = 1, int pageSize = 50, CancellationToken ct = default)
+    {
+        page = page < 1 ? 1 : page;
+        pageSize = pageSize is < 1 or > 200 ? 50 : pageSize;
+
+        IQueryable<AuditEvent> query = _db.AuditEvents.AsNoTracking();
+        int total = await query.CountAsync(ct);
+
+        List<AuditEventRow> items = await query
+            .OrderByDescending(a => a.OccurredAtUtc)
+            .ThenByDescending(a => a.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(a => new AuditEventRow
+            {
+                Id = a.Id,
+                OccurredAtUtc = a.OccurredAtUtc,
+                ActorName = a.ActorName,
+                Action = a.Action,
+                Target = a.Target,
+                Detail = a.Detail
+            })
+            .ToListAsync(ct);
+
+        return Ok(new PagedResult<AuditEventRow> { Items = items, Page = page, PageSize = pageSize, TotalCount = total });
+    }
+
+    [HttpGet("verbose")]
+    public ActionResult<VerboseStatusResponse> GetVerbose() => Ok(BuildVerboseStatus());
+
+    [HttpPut("verbose")]
+    public async Task<ActionResult<VerboseStatusResponse>> SetVerbose([FromBody] VerboseRequest request, CancellationToken ct)
+    {
+        if (request.Enabled)
+        {
+            _levelSwitch.EnableVerbose();
+            await _audit.WriteAsync(AuditActions.VerboseEnabled, detail: $"auto-off {LogLevelSwitch.VerboseDuration.TotalHours:0.#} h", ct: ct);
+        }
+        else
+        {
+            _levelSwitch.DisableVerbose();
+            await _audit.WriteAsync(AuditActions.VerboseDisabled, ct: ct);
+        }
+
+        return Ok(BuildVerboseStatus());
+    }
+
+    private VerboseStatusResponse BuildVerboseStatus() => new()
+    {
+        Enabled = _levelSwitch.VerboseEnabled,
+        UntilUtc = _levelSwitch.VerboseUntilUtc
+    };
+
+    private static bool TryParseLevel(string? level, out LogLevel parsed)
+    {
+        parsed = LogLevel.Trace;
+        return !string.IsNullOrWhiteSpace(level) && Enum.TryParse(level, ignoreCase: true, out parsed) && parsed != LogLevel.None;
+    }
+}

--- a/src/FairShare.Api/Controllers/StatsController.cs
+++ b/src/FairShare.Api/Controllers/StatsController.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Observability;
+using FairShare.Contracts.Observability;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FairShare.Api.Controllers;
+
+[Authorize(Policy = "AdminOnly")]
+[ApiController]
+[Route("api/v1/admin/stats")]
+public class StatsController(IAnalyticsService analytics) : ControllerBase
+{
+    private readonly IAnalyticsService _analytics = analytics;
+
+    /// <param name="days">Period in days ending today; null or 0 means all time.</param>
+    [HttpGet("summary")]
+    public async Task<ActionResult<StatsSummaryResponse>> GetSummary(int? days, CancellationToken ct) =>
+        Ok(await _analytics.GetSummaryAsync(Normalize(days), ct));
+
+    [HttpGet("pages")]
+    public async Task<ActionResult<PagedResult<PageStatRow>>> GetPages(
+        int? days, int page = 1, int pageSize = 10, string sort = "views", bool desc = true, CancellationToken ct = default)
+    {
+        page = page < 1 ? 1 : page;
+        pageSize = pageSize is < 1 or > 100 ? 10 : pageSize;
+        return Ok(await _analytics.GetTopPagesAsync(Normalize(days), page, pageSize, sort, desc, ct));
+    }
+
+    [HttpGet("referrers")]
+    public async Task<ActionResult<List<ReferrerStatRow>>> GetReferrers(int? days, CancellationToken ct) =>
+        Ok(await _analytics.GetTopReferrersAsync(Normalize(days), take: 10, ct));
+
+    [HttpGet("events")]
+    public async Task<ActionResult<List<EventStatRow>>> GetEvents(int? days, CancellationToken ct) =>
+        Ok(await _analytics.GetEventsAsync(Normalize(days), ct));
+
+    private static int? Normalize(int? days) => days is int d && d > 0 ? d : null;
+}

--- a/src/FairShare.Api/Controllers/UsersController.cs
+++ b/src/FairShare.Api/Controllers/UsersController.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System;
 using FairShare.Api.Auth;
 using FairShare.Api.Models;
+using FairShare.Api.Observability;
 using FairShare.Contracts.Admin;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -16,11 +17,12 @@ namespace FairShare.Api.Controllers;
 [Authorize(Policy = "AdminOnly")]
 [ApiController]
 [Route("api/v1/admin/users")]
-public class UsersController(UserManager<ApplicationUser> um, RoleManager<IdentityRole<Guid>> rm, ITokenService tokenService) : ControllerBase
+public class UsersController(UserManager<ApplicationUser> um, RoleManager<IdentityRole<Guid>> rm, ITokenService tokenService, IAuditService audit) : ControllerBase
 {
     private readonly UserManager<ApplicationUser> _userManager = um;
     private readonly RoleManager<IdentityRole<Guid>> _roleManager = rm;
     private readonly ITokenService _tokenService = tokenService;
+    private readonly IAuditService _audit = audit;
 
     [HttpGet]
     public async Task<ActionResult<IEnumerable<UserListItem>>> GetUsers(string filter = "all")
@@ -86,6 +88,7 @@ public class UsersController(UserManager<ApplicationUser> um, RoleManager<Identi
         if (!result.Succeeded) return BadRequest(result.Errors);
 
         await _userManager.AddToRoleAsync(user, model.Role);
+        await _audit.WriteAsync(AuditActions.UserCreated, target: user.UserName, detail: $"role {model.Role}");
         return CreatedAtAction(nameof(GetUser), new { id = user.Id }, user);
     }
 
@@ -111,6 +114,11 @@ public class UsersController(UserManager<ApplicationUser> um, RoleManager<Identi
             await _userManager.RemoveFromRolesAsync(user, existingRoles);
             await _userManager.AddToRoleAsync(user, model.Role);
         }
+
+        await _audit.WriteAsync(
+            AuditActions.UserUpdated,
+            target: user.UserName,
+            detail: $"role {model.Role}{(model.IsDisabled ? ", disabled" : string.Empty)}");
 
         return NoContent();
     }
@@ -150,6 +158,7 @@ public class UsersController(UserManager<ApplicationUser> um, RoleManager<Identi
         }
 
         await _tokenService.RevokeAllForUserAsync(user.Id, ct);
+        await _audit.WriteAsync(AuditActions.PasswordReset, target: user.UserName, ct: ct);
 
         return NoContent();
     }
@@ -170,6 +179,7 @@ public class UsersController(UserManager<ApplicationUser> um, RoleManager<Identi
         if (user is null) return NotFound();
 
         await _userManager.DeleteAsync(user);
+        await _audit.WriteAsync(AuditActions.UserDeleted, target: user.UserName);
         return NoContent();
     }
 }

--- a/src/FairShare.Api/Migrations/20260820192423_AddObservability.Designer.cs
+++ b/src/FairShare.Api/Migrations/20260820192423_AddObservability.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FairShare.Api.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FairShare.Api.Migrations
 {
     [DbContext(typeof(FairShareDbContext))]
-    partial class FairShareDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260820192423_AddObservability")]
+    partial class AddObservability
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/FairShare.Api/Migrations/20260820192423_AddObservability.cs
+++ b/src/FairShare.Api/Migrations/20260820192423_AddObservability.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FairShare.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddObservability : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AnalyticsEvents",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 40, nullable: false),
+                    Target = table.Column<string>(type: "TEXT", maxLength: 300, nullable: true),
+                    VisitorKey = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    OccurredAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnalyticsEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AnalyticsStates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    SecretBase64 = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnalyticsStates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AuditEvents",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    OccurredAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    ActorUserId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    ActorName = table.Column<string>(type: "TEXT", maxLength: 64, nullable: true),
+                    Action = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    Target = table.Column<string>(type: "TEXT", maxLength: 128, nullable: true),
+                    Detail = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DailyEventStats",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Day = table.Column<DateOnly>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 40, nullable: false),
+                    Target = table.Column<string>(type: "TEXT", maxLength: 300, nullable: true),
+                    Count = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DailyEventStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DailyReferrerStats",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Day = table.Column<DateOnly>(type: "TEXT", nullable: false),
+                    ReferrerHost = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Views = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DailyReferrerStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DailyRouteStats",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Day = table.Column<DateOnly>(type: "TEXT", nullable: false),
+                    Path = table.Column<string>(type: "TEXT", maxLength: 300, nullable: false),
+                    Views = table.Column<long>(type: "INTEGER", nullable: false),
+                    Visitors = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DailyRouteStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DailySiteStats",
+                columns: table => new
+                {
+                    Day = table.Column<DateOnly>(type: "TEXT", nullable: false),
+                    Views = table.Column<long>(type: "INTEGER", nullable: false),
+                    Visitors = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DailySiteStats", x => x.Day);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Logs",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    OccurredAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Level = table.Column<int>(type: "INTEGER", nullable: false),
+                    Category = table.Column<string>(type: "TEXT", maxLength: 160, nullable: false),
+                    Message = table.Column<string>(type: "TEXT", maxLength: 2000, nullable: false),
+                    Exception = table.Column<string>(type: "TEXT", maxLength: 4000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Logs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PageViews",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Path = table.Column<string>(type: "TEXT", maxLength: 300, nullable: false),
+                    ReferrerHost = table.Column<string>(type: "TEXT", maxLength: 200, nullable: true),
+                    VisitorKey = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    OccurredAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageViews", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnalyticsEvents_OccurredAtUtc",
+                table: "AnalyticsEvents",
+                column: "OccurredAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditEvents_OccurredAtUtc",
+                table: "AuditEvents",
+                column: "OccurredAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyEventStats_Day_Name",
+                table: "DailyEventStats",
+                columns: new[] { "Day", "Name" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyReferrerStats_Day_ReferrerHost",
+                table: "DailyReferrerStats",
+                columns: new[] { "Day", "ReferrerHost" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyRouteStats_Day_Path",
+                table: "DailyRouteStats",
+                columns: new[] { "Day", "Path" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Logs_OccurredAtUtc",
+                table: "Logs",
+                column: "OccurredAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageViews_OccurredAtUtc",
+                table: "PageViews",
+                column: "OccurredAtUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AnalyticsEvents");
+
+            migrationBuilder.DropTable(
+                name: "AnalyticsStates");
+
+            migrationBuilder.DropTable(
+                name: "AuditEvents");
+
+            migrationBuilder.DropTable(
+                name: "DailyEventStats");
+
+            migrationBuilder.DropTable(
+                name: "DailyReferrerStats");
+
+            migrationBuilder.DropTable(
+                name: "DailyRouteStats");
+
+            migrationBuilder.DropTable(
+                name: "DailySiteStats");
+
+            migrationBuilder.DropTable(
+                name: "Logs");
+
+            migrationBuilder.DropTable(
+                name: "PageViews");
+        }
+    }
+}

--- a/src/FairShare.Api/Observability/AnalyticsEntities.cs
+++ b/src/FairShare.Api/Observability/AnalyticsEntities.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// One qualifying page view. Raw rows live 90 days, then only the Daily* aggregates remain.
+/// VisitorKey is an HMAC whose payload includes the UTC date, so keys cannot be linked
+/// across days; the IP and user-agent that feed it are never stored (ADR 0003).
+/// </summary>
+public class PageView
+{
+    public const int MaxPathLength = 300;
+    public const int MaxReferrerHostLength = 200;
+    public const int MaxVisitorKeyLength = 64;
+
+    public long Id { get; set; }
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Host only, external referrers only; null for direct or internal navigation.</summary>
+    public string? ReferrerHost { get; set; }
+
+    public string VisitorKey { get; set; } = string.Empty;
+    public DateTime OccurredAtUtc { get; set; }
+}
+
+/// <summary>
+/// One content-free analytics event: a name plus a coarse target (form key, gate name),
+/// never case content (NFR-1). Raw rows live 90 days.
+/// </summary>
+public class AnalyticsEvent
+{
+    public const int MaxNameLength = 40;
+    public const int MaxTargetLength = 300;
+
+    public long Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Target { get; set; }
+    public string VisitorKey { get; set; } = string.Empty;
+    public DateTime OccurredAtUtc { get; set; }
+}
+
+/// <summary>Singleton row (Id = 1) holding the per-install HMAC secret for visitor keys.</summary>
+public class AnalyticsState
+{
+    public int Id { get; set; }
+    public string SecretBase64 { get; set; } = string.Empty;
+}

--- a/src/FairShare.Api/Observability/AnalyticsRollup.cs
+++ b/src/FairShare.Api/Observability/AnalyticsRollup.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>Pure aggregation of one UTC day's raw rows into the four Daily* shapes.</summary>
+public static class AnalyticsRollup
+{
+    public static readonly TimeSpan RawRetention = TimeSpan.FromDays(90);
+    public static readonly TimeSpan LogRetention = TimeSpan.FromDays(30);
+    public static readonly TimeSpan AuditRetention = TimeSpan.FromDays(365);
+
+    /// <summary>00:20 UTC: 20 minutes of slack after midnight for clock skew.</summary>
+    public static readonly TimeSpan DailyRunTime = new(0, 20, 0);
+
+    public static (DailySiteStat Site, List<DailyRouteStat> Routes, List<DailyReferrerStat> Referrers, List<DailyEventStat> Events)
+        ComputeDay(DateOnly day, IReadOnlyCollection<PageView> pageViews, IReadOnlyCollection<AnalyticsEvent> events)
+    {
+        DailySiteStat site = new()
+        {
+            Day = day,
+            Views = pageViews.Count,
+            Visitors = pageViews.Select(v => v.VisitorKey).Distinct().Count()
+        };
+
+        List<DailyRouteStat> routes = pageViews
+            .GroupBy(v => v.Path)
+            .Select(g => new DailyRouteStat
+            {
+                Day = day,
+                Path = g.Key,
+                Views = g.Count(),
+                Visitors = g.Select(v => v.VisitorKey).Distinct().Count()
+            })
+            .ToList();
+
+        List<DailyReferrerStat> referrers = pageViews
+            .Where(v => v.ReferrerHost is not null)
+            .GroupBy(v => v.ReferrerHost!)
+            .Select(g => new DailyReferrerStat { Day = day, ReferrerHost = g.Key, Views = g.Count() })
+            .ToList();
+
+        List<DailyEventStat> eventStats = events
+            .GroupBy(e => (e.Name, e.Target))
+            .Select(g => new DailyEventStat { Day = day, Name = g.Key.Name, Target = g.Key.Target, Count = g.Count() })
+            .ToList();
+
+        return (site, routes, referrers, eventStats);
+    }
+
+    /// <summary>UTC start/end of a day, kinds pinned so timestamptz-style engines stay happy.</summary>
+    public static (DateTime StartUtc, DateTime EndUtc) DayBounds(DateOnly day)
+    {
+        DateTime start = day.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        return (start, start.AddDays(1));
+    }
+
+    public static DateTime NextRunUtc(DateTime nowUtc)
+    {
+        DateTime todayRun = nowUtc.Date + DailyRunTime;
+        return nowUtc < todayRun ? todayRun : todayRun.AddDays(1);
+    }
+}

--- a/src/FairShare.Api/Observability/AnalyticsRules.cs
+++ b/src/FairShare.Api/Observability/AnalyticsRules.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>Event names the analytics pipeline records (name + coarse target, never content).</summary>
+public static class AnalyticsEventNames
+{
+    public const string CalculationStarted = "calculation-started";
+    public const string CalculationCompleted = "calculation-completed";
+    public const string GatedHit = "gated-hit";
+    public const string DonateClick = "donate-click";
+
+    /// <summary>
+    /// The only names a browser may post directly. Server-observed events (calculations,
+    /// donate redirects) are recorded server-side so clients cannot forge them.
+    /// </summary>
+    public static readonly string[] ClientPostable = [GatedHit];
+}
+
+/// <summary>
+/// The pure capture rules of ADR 0003. Everything here is static and unit-tested; the
+/// service layer applies them, it does not interpret them.
+/// </summary>
+public static class AnalyticsRules
+{
+    // Substring markers; matching is case-insensitive. An empty/missing UA is treated as a
+    // bot too - every real browser sends one.
+    private static readonly string[] BotMarkers =
+    [
+        "bot", "crawl", "spider", "slurp", "curl", "wget", "python", "httpclient",
+        "headless", "lighthouse", "preview", "facebookexternalhit", "monitor"
+    ];
+
+    // Path prefixes that are never countable: admin/auth surfaces, machine endpoints,
+    // and framework internals.
+    private static readonly string[] ExcludedPrefixes =
+    [
+        "/admin", "/login", "/register", "/account", "/go", "/healthz", "/swagger", "/api"
+    ];
+
+    public static bool IsBot(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return true;
+        }
+
+        return BotMarkers.Any(marker => userAgent.Contains(marker, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>DNT and Global Privacy Control both mean: record nothing at all.</summary>
+    public static bool OptedOut(IHeaderDictionary headers) =>
+        headers["DNT"] == "1" || headers["Sec-GPC"] == "1";
+
+    /// <summary>
+    /// Normalizes an SPA route to its countable form (lowercase, no query/fragment, leading
+    /// slash) or rejects it. File-looking last segments (a dot) are never countable.
+    /// </summary>
+    public static bool TryNormalizePath(string? rawPath, out string normalized)
+    {
+        normalized = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(rawPath) || !rawPath.StartsWith('/') || rawPath.StartsWith("//", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string path = rawPath;
+        int cut = path.IndexOfAny(['?', '#']);
+        if (cut >= 0)
+        {
+            path = path[..cut];
+        }
+
+        if (path.Length == 0 || path.Length > PageView.MaxPathLength)
+        {
+            return false;
+        }
+
+        path = path.ToLowerInvariant();
+
+        if (path.Length > 1 && path.EndsWith('/'))
+        {
+            path = path.TrimEnd('/');
+        }
+
+        if (ExcludedPrefixes.Any(prefix => path == prefix || path.StartsWith(prefix + "/", StringComparison.Ordinal))
+            || path.StartsWith("/_", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string lastSegment = path[(path.LastIndexOf('/') + 1)..];
+        if (lastSegment.Contains('.'))
+        {
+            return false;
+        }
+
+        normalized = path;
+        return true;
+    }
+
+    /// <summary>External referrer host, or null for direct/internal/unparseable referrers.</summary>
+    public static string? NormalizeReferrer(string? referrer, string? ownHost)
+    {
+        if (string.IsNullOrWhiteSpace(referrer) || !Uri.TryCreate(referrer, UriKind.Absolute, out Uri? uri))
+        {
+            return null;
+        }
+
+        string host = uri.Host.ToLowerInvariant();
+
+        if (host.Length == 0 || host.Length > PageView.MaxReferrerHostLength)
+        {
+            return null;
+        }
+
+        return string.Equals(host, ownHost, StringComparison.OrdinalIgnoreCase) ? null : host;
+    }
+
+    /// <summary>
+    /// Validates a client-posted event. Only whitelisted names pass, and targets are held to
+    /// kebab-case tokens - a shape that cannot smuggle case content (NFR-1).
+    /// </summary>
+    public static bool TryNormalizeClientEvent(string? name, string? rawTarget, out string normalizedName, out string? normalizedTarget)
+    {
+        normalizedName = string.Empty;
+        normalizedTarget = null;
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        string candidate = name.Trim().ToLowerInvariant();
+        if (!AnalyticsEventNames.ClientPostable.Contains(candidate))
+        {
+            return false;
+        }
+
+        normalizedName = candidate;
+
+        if (!string.IsNullOrWhiteSpace(rawTarget))
+        {
+            string target = rawTarget.Trim().ToLowerInvariant();
+            if (target.Length > 40 || !target.All(c => char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c is '-' or '/'))
+            {
+                return false;
+            }
+
+            normalizedTarget = target;
+        }
+
+        return true;
+    }
+}

--- a/src/FairShare.Api/Observability/AnalyticsSecretProvider.cs
+++ b/src/FairShare.Api/Observability/AnalyticsSecretProvider.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// Caches the per-install HMAC secret, creating it lazily on first use. Two instances racing
+/// the first insert is resolved by re-reading: the row that won is the truth for both.
+/// </summary>
+public class AnalyticsSecretProvider(IServiceScopeFactory scopeFactory)
+{
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private byte[]? _secret;
+
+    public async Task<byte[]> GetSecretAsync(CancellationToken ct = default)
+    {
+        if (_secret is not null)
+        {
+            return _secret;
+        }
+
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_secret is not null)
+            {
+                return _secret;
+            }
+
+            using IServiceScope scope = _scopeFactory.CreateScope();
+            FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+            AnalyticsState? state = await db.AnalyticsStates.SingleOrDefaultAsync(s => s.Id == 1, ct);
+
+            if (state is null)
+            {
+                state = new AnalyticsState { Id = 1, SecretBase64 = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)) };
+                db.AnalyticsStates.Add(state);
+
+                try
+                {
+                    await db.SaveChangesAsync(ct);
+                }
+                catch (DbUpdateException)
+                {
+                    // Another instance created it first; theirs wins.
+                    db.Entry(state).State = EntityState.Detached;
+                    state = await db.AnalyticsStates.SingleAsync(s => s.Id == 1, ct);
+                }
+            }
+
+            _secret = Convert.FromBase64String(state.SecretBase64);
+            return _secret;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}

--- a/src/FairShare.Api/Observability/AnalyticsService.cs
+++ b/src/FairShare.Api/Observability/AnalyticsService.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Persistence;
+using FairShare.Contracts.Observability;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Observability;
+
+public interface IAnalyticsService
+{
+    /// <summary>Records a page view if every capture rule passes. Best-effort, never throws.</summary>
+    Task RecordPageViewAsync(HttpContext context, string? path, string? referrer, CancellationToken ct = default);
+
+    /// <summary>Records a content-free event if the capture rules pass. Best-effort, never throws.</summary>
+    Task RecordEventAsync(HttpContext context, string name, string? target, CancellationToken ct = default);
+
+    Task<StatsSummaryResponse> GetSummaryAsync(int? days, CancellationToken ct = default);
+    Task<PagedResult<PageStatRow>> GetTopPagesAsync(int? days, int page, int pageSize, string sort, bool descending, CancellationToken ct = default);
+    Task<List<ReferrerStatRow>> GetTopReferrersAsync(int? days, int take, CancellationToken ct = default);
+    Task<List<EventStatRow>> GetEventsAsync(int? days, CancellationToken ct = default);
+}
+
+public class AnalyticsService(
+    FairShareDbContext db,
+    AnalyticsSecretProvider secretProvider,
+    TimeProvider time,
+    ILogger<AnalyticsService> logger) : IAnalyticsService
+{
+    private readonly FairShareDbContext _db = db;
+    private readonly AnalyticsSecretProvider _secretProvider = secretProvider;
+    private readonly TimeProvider _time = time;
+    private readonly ILogger<AnalyticsService> _logger = logger;
+
+    public async Task RecordPageViewAsync(HttpContext context, string? path, string? referrer, CancellationToken ct = default)
+    {
+        try
+        {
+            if (!ShouldRecord(context, out string ip, out string userAgent)
+                || !AnalyticsRules.TryNormalizePath(path, out string normalizedPath))
+            {
+                return;
+            }
+
+            DateTime nowUtc = _time.GetUtcNow().UtcDateTime;
+            byte[] secret = await _secretProvider.GetSecretAsync(ct);
+
+            _db.PageViews.Add(new PageView
+            {
+                Path = normalizedPath,
+                ReferrerHost = AnalyticsRules.NormalizeReferrer(referrer, context.Request.Host.Host),
+                VisitorKey = VisitorKey.Compute(secret, DateOnly.FromDateTime(nowUtc), ip, userAgent),
+                OccurredAtUtc = nowUtc
+            });
+
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            // Telemetry must never fail a request (NFR-4).
+            _logger.LogWarning(ex, "Page-view recording failed.");
+        }
+    }
+
+    public async Task RecordEventAsync(HttpContext context, string name, string? target, CancellationToken ct = default)
+    {
+        try
+        {
+            if (!ShouldRecord(context, out string ip, out string userAgent))
+            {
+                return;
+            }
+
+            DateTime nowUtc = _time.GetUtcNow().UtcDateTime;
+            byte[] secret = await _secretProvider.GetSecretAsync(ct);
+
+            _db.AnalyticsEvents.Add(new AnalyticsEvent
+            {
+                Name = name,
+                Target = target,
+                VisitorKey = VisitorKey.Compute(secret, DateOnly.FromDateTime(nowUtc), ip, userAgent),
+                OccurredAtUtc = nowUtc
+            });
+
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Analytics event recording failed for {EventName}.", name);
+        }
+    }
+
+    private static bool ShouldRecord(HttpContext context, out string ip, out string userAgent)
+    {
+        ip = string.Empty;
+        userAgent = context.Request.Headers.UserAgent.ToString();
+
+        if (AnalyticsRules.OptedOut(context.Request.Headers)
+            || AnalyticsRules.IsBot(userAgent)
+            || context.User.IsInRole("Admin"))
+        {
+            return false;
+        }
+
+        // First X-Forwarded-For hop when the proxy supplies one, else the peer. Only the
+        // visitor hash consumes this, so a spoofed header can at worst split or merge
+        // daily-visitor counts - the rate limiter's peer-IP keying is deliberately untouched.
+        string forwarded = context.Request.Headers["X-Forwarded-For"].ToString();
+        ip = !string.IsNullOrWhiteSpace(forwarded)
+            ? forwarded.Split(',')[0].Trim()
+            : context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+        return true;
+    }
+
+    // ---- Queries ------------------------------------------------------------------
+
+    public async Task<StatsSummaryResponse> GetSummaryAsync(int? days, CancellationToken ct = default)
+    {
+        (DateOnly from, DateOnly today) = await ResolveRangeAsync(days, ct);
+
+        List<DailySiteStat> siteStats = await _db.DailySiteStats
+            .Where(s => s.Day >= from && s.Day < today)
+            .ToListAsync(ct);
+
+        (DateTime todayStart, _) = AnalyticsRollup.DayBounds(today);
+
+        List<PageView> todayViews = await _db.PageViews
+            .Where(v => v.OccurredAtUtc >= todayStart)
+            .ToListAsync(ct);
+
+        Dictionary<(string Name, string? Target), long> eventCounts = await GetEventCountsAsync(from, today, ct);
+
+        DateOnly? firstDay = await _db.DailySiteStats.OrderBy(s => s.Day).Select(s => (DateOnly?)s.Day).FirstOrDefaultAsync(ct);
+        if (firstDay is null && (todayViews.Count > 0 || eventCounts.Count > 0))
+        {
+            firstDay = today;
+        }
+
+        return new StatsSummaryResponse
+        {
+            PageViews = siteStats.Sum(s => s.Views) + todayViews.Count,
+            DailyVisitors = siteStats.Sum(s => s.Visitors) + todayViews.Select(v => v.VisitorKey).Distinct().Count(),
+            CalculationsCompleted = SumEvent(eventCounts, AnalyticsEventNames.CalculationCompleted),
+            GatedHits = SumEvent(eventCounts, AnalyticsEventNames.GatedHit),
+            DonateClicks = SumEvent(eventCounts, AnalyticsEventNames.DonateClick),
+            FirstDay = firstDay
+        };
+    }
+
+    public async Task<PagedResult<PageStatRow>> GetTopPagesAsync(int? days, int page, int pageSize, string sort, bool descending, CancellationToken ct = default)
+    {
+        (DateOnly from, DateOnly today) = await ResolveRangeAsync(days, ct);
+
+        List<DailyRouteStat> rolled = await _db.DailyRouteStats
+            .Where(s => s.Day >= from && s.Day < today)
+            .ToListAsync(ct);
+
+        (DateTime todayStart, _) = AnalyticsRollup.DayBounds(today);
+        List<PageView> todayViews = await _db.PageViews
+            .Where(v => v.OccurredAtUtc >= todayStart)
+            .ToListAsync(ct);
+
+        Dictionary<string, PageStatRow> byPath = new(StringComparer.Ordinal);
+
+        foreach (DailyRouteStat stat in rolled)
+        {
+            PageStatRow row = GetOrAdd(byPath, stat.Path);
+            row.Views += stat.Views;
+            row.Visitors += stat.Visitors;
+        }
+
+        foreach (IGrouping<string, PageView> group in todayViews.GroupBy(v => v.Path))
+        {
+            PageStatRow row = GetOrAdd(byPath, group.Key);
+            row.Views += group.Count();
+            row.Visitors += group.Select(v => v.VisitorKey).Distinct().Count();
+        }
+
+        IEnumerable<PageStatRow> ordered = sort.ToLowerInvariant() switch
+        {
+            "path" => descending ? byPath.Values.OrderByDescending(r => r.Path) : byPath.Values.OrderBy(r => r.Path),
+            "visitors" => descending ? byPath.Values.OrderByDescending(r => r.Visitors) : byPath.Values.OrderBy(r => r.Visitors),
+            _ => descending ? byPath.Values.OrderByDescending(r => r.Views) : byPath.Values.OrderBy(r => r.Views)
+        };
+
+        List<PageStatRow> all = ordered.ToList();
+
+        return new PagedResult<PageStatRow>
+        {
+            Items = all.Skip((page - 1) * pageSize).Take(pageSize).ToList(),
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = all.Count
+        };
+
+        static PageStatRow GetOrAdd(Dictionary<string, PageStatRow> map, string path)
+        {
+            if (!map.TryGetValue(path, out PageStatRow? row))
+            {
+                row = new PageStatRow { Path = path };
+                map[path] = row;
+            }
+
+            return row;
+        }
+    }
+
+    public async Task<List<ReferrerStatRow>> GetTopReferrersAsync(int? days, int take, CancellationToken ct = default)
+    {
+        (DateOnly from, DateOnly today) = await ResolveRangeAsync(days, ct);
+
+        List<DailyReferrerStat> rolled = await _db.DailyReferrerStats
+            .Where(s => s.Day >= from && s.Day < today)
+            .ToListAsync(ct);
+
+        (DateTime todayStart, _) = AnalyticsRollup.DayBounds(today);
+        List<string> todayHosts = await _db.PageViews
+            .Where(v => v.OccurredAtUtc >= todayStart && v.ReferrerHost != null)
+            .Select(v => v.ReferrerHost!)
+            .ToListAsync(ct);
+
+        return rolled
+            .Select(s => (Host: s.ReferrerHost, Views: s.Views))
+            .Concat(todayHosts.GroupBy(h => h).Select(g => (Host: g.Key, Views: (long)g.Count())))
+            .GroupBy(t => t.Host)
+            .Select(g => new ReferrerStatRow { ReferrerHost = g.Key, Views = g.Sum(t => t.Views) })
+            .OrderByDescending(r => r.Views)
+            .Take(take)
+            .ToList();
+    }
+
+    public async Task<List<EventStatRow>> GetEventsAsync(int? days, CancellationToken ct = default)
+    {
+        (DateOnly from, DateOnly today) = await ResolveRangeAsync(days, ct);
+        Dictionary<(string Name, string? Target), long> counts = await GetEventCountsAsync(from, today, ct);
+
+        return counts
+            .Select(kvp => new EventStatRow { Name = kvp.Key.Name, Target = kvp.Key.Target, Count = kvp.Value })
+            .OrderByDescending(r => r.Count)
+            .ToList();
+    }
+
+    private async Task<Dictionary<(string Name, string? Target), long>> GetEventCountsAsync(DateOnly from, DateOnly today, CancellationToken ct)
+    {
+        List<DailyEventStat> rolled = await _db.DailyEventStats
+            .Where(s => s.Day >= from && s.Day < today)
+            .ToListAsync(ct);
+
+        (DateTime todayStart, _) = AnalyticsRollup.DayBounds(today);
+        List<AnalyticsEvent> todayEvents = await _db.AnalyticsEvents
+            .Where(e => e.OccurredAtUtc >= todayStart)
+            .ToListAsync(ct);
+
+        Dictionary<(string, string?), long> counts = [];
+
+        foreach (DailyEventStat stat in rolled)
+        {
+            (string, string?) key = (stat.Name, stat.Target);
+            counts[key] = counts.GetValueOrDefault(key) + stat.Count;
+        }
+
+        foreach (AnalyticsEvent evt in todayEvents)
+        {
+            (string, string?) key = (evt.Name, evt.Target);
+            counts[key] = counts.GetValueOrDefault(key) + 1;
+        }
+
+        return counts;
+    }
+
+    private static long SumEvent(Dictionary<(string Name, string? Target), long> counts, string name) =>
+        counts.Where(kvp => kvp.Key.Name == name).Sum(kvp => kvp.Value);
+
+    /// <summary>Inclusive from-day and today (exclusive upper bound for rollups; live otherwise).</summary>
+    private async Task<(DateOnly From, DateOnly Today)> ResolveRangeAsync(int? days, CancellationToken ct)
+    {
+        DateOnly today = DateOnly.FromDateTime(_time.GetUtcNow().UtcDateTime);
+
+        if (days is int d && d > 0)
+        {
+            return (today.AddDays(-(d - 1)), today);
+        }
+
+        // All time: from the earliest rolled-up day (or today when nothing is rolled yet).
+        DateOnly? first = await _db.DailySiteStats.OrderBy(s => s.Day).Select(s => (DateOnly?)s.Day).FirstOrDefaultAsync(ct);
+        return (first ?? today, today);
+    }
+}

--- a/src/FairShare.Api/Observability/AuditEvent.cs
+++ b/src/FairShare.Api/Observability/AuditEvent.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// One accountability record: sign-ins, account changes, verbose-mode toggles. Retained ~1 year
+/// and deliberately not FK-bound to users - an audit row must outlive the account it names
+/// (ADR 0003/0004), so actor identity is copied as it was at the time of the action.
+/// </summary>
+public class AuditEvent
+{
+    public const int MaxActorNameLength = 64;
+    public const int MaxActionLength = 64;
+    public const int MaxTargetLength = 128;
+    public const int MaxDetailLength = 256;
+
+    public long Id { get; set; }
+    public DateTime OccurredAtUtc { get; set; }
+    public Guid? ActorUserId { get; set; }
+    public string? ActorName { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string? Target { get; set; }
+    public string? Detail { get; set; }
+}

--- a/src/FairShare.Api/Observability/AuditService.cs
+++ b/src/FairShare.Api/Observability/AuditService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>Well-known audit action names. Values are what the admin log viewer shows.</summary>
+public static class AuditActions
+{
+    public const string LoginSucceeded = "login-succeeded";
+    public const string LoginFailed = "login-failed";
+    public const string Registered = "registered";
+    public const string PasswordChanged = "password-changed";
+    public const string UserCreated = "user-created";
+    public const string UserUpdated = "user-updated";
+    public const string UserDeleted = "user-deleted";
+    public const string PasswordReset = "password-reset";
+    public const string VerboseEnabled = "verbose-enabled";
+    public const string VerboseDisabled = "verbose-disabled";
+}
+
+public interface IAuditService
+{
+    /// <summary>
+    /// Records an accountability event. Best-effort: an audit failure is logged and swallowed,
+    /// never surfaced into the request that triggered it.
+    /// </summary>
+    Task WriteAsync(string action, string? target = null, string? detail = null, CancellationToken ct = default);
+}
+
+public class AuditService(FairShareDbContext db, IHttpContextAccessor httpContextAccessor, ILogger<AuditService> logger) : IAuditService
+{
+    private readonly FairShareDbContext _db = db;
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+    private readonly ILogger<AuditService> _logger = logger;
+
+    public async Task WriteAsync(string action, string? target = null, string? detail = null, CancellationToken ct = default)
+    {
+        try
+        {
+            ClaimsPrincipal? actor = _httpContextAccessor.HttpContext?.User;
+            Guid? actorId = Guid.TryParse(actor?.FindFirstValue(ClaimTypes.NameIdentifier), out Guid parsed) ? parsed : null;
+            string? actorName = actor?.Identity?.Name
+                ?? (actor?.HasClaim(c => c.Type == "guest" && c.Value == "true") == true ? "guest" : null);
+
+            _db.AuditEvents.Add(new AuditEvent
+            {
+                OccurredAtUtc = DateTime.UtcNow,
+                ActorUserId = actorId,
+                ActorName = Truncate(actorName, AuditEvent.MaxActorNameLength),
+                Action = Truncate(action, AuditEvent.MaxActionLength)!,
+                Target = Truncate(target, AuditEvent.MaxTargetLength),
+                Detail = Truncate(detail, AuditEvent.MaxDetailLength)
+            });
+
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Audit write failed for action {Action}.", action);
+        }
+    }
+
+    private static string? Truncate(string? value, int max) =>
+        value is null || value.Length <= max ? value : value[..max];
+}

--- a/src/FairShare.Api/Observability/DailyStats.cs
+++ b/src/FairShare.Api/Observability/DailyStats.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// Permanent per-UTC-day aggregate. The maximum Day also serves as the rollup watermark:
+/// zero-traffic days still get a row so the watermark always advances.
+/// </summary>
+public class DailySiteStat
+{
+    public DateOnly Day { get; set; }
+    public long Views { get; set; }
+
+    /// <summary>Distinct visitor keys that day ("Daily visitors" - never "unique visitors").</summary>
+    public long Visitors { get; set; }
+}
+
+public class DailyRouteStat
+{
+    public long Id { get; set; }
+    public DateOnly Day { get; set; }
+    public string Path { get; set; } = string.Empty;
+    public long Views { get; set; }
+    public long Visitors { get; set; }
+}
+
+public class DailyReferrerStat
+{
+    public long Id { get; set; }
+    public DateOnly Day { get; set; }
+    public string ReferrerHost { get; set; } = string.Empty;
+    public long Views { get; set; }
+}
+
+public class DailyEventStat
+{
+    public long Id { get; set; }
+    public DateOnly Day { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Target { get; set; }
+    public long Count { get; set; }
+}

--- a/src/FairShare.Api/Observability/LogEntry.cs
+++ b/src/FairShare.Api/Observability/LogEntry.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// One diagnostic log row. Retained 30 days (see <see cref="ObservabilityMaintenanceService"/>).
+/// Never contains case content, names, or money amounts (ADR 0003).
+/// </summary>
+public class LogEntry
+{
+    public const int MaxCategoryLength = 160;
+    public const int MaxMessageLength = 2000;
+    public const int MaxExceptionLength = 4000;
+
+    public long Id { get; set; }
+    public DateTime OccurredAtUtc { get; set; }
+
+    /// <summary>Microsoft.Extensions.Logging.LogLevel as its integer value.</summary>
+    public int Level { get; set; }
+
+    public string Category { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string? Exception { get; set; }
+}

--- a/src/FairShare.Api/Observability/LogLevelSwitch.cs
+++ b/src/FairShare.Api/Observability/LogLevelSwitch.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// Runtime minimum-level switch for the SQLite log sink. Normal capture: FairShare.* at
+/// Information, everything else at Warning. Verbose mode drops those to Debug/Information
+/// and always turns itself back off: expiry is checked on read, and a process restart
+/// resets it (the state is deliberately in-memory only - ADR 0003).
+/// </summary>
+public class LogLevelSwitch(TimeProvider time)
+{
+    public static readonly TimeSpan VerboseDuration = TimeSpan.FromHours(4);
+
+    private readonly TimeProvider _time = time;
+
+    // UTC ticks until which verbose mode is active; 0 = off. Interlocked because the
+    // admin endpoint writes while every log call site reads.
+    private long _verboseUntilUtcTicks;
+
+    public bool VerboseEnabled => Volatile.Read(ref _verboseUntilUtcTicks) > _time.GetUtcNow().UtcTicks;
+
+    public DateTime? VerboseUntilUtc
+    {
+        get
+        {
+            long ticks = Volatile.Read(ref _verboseUntilUtcTicks);
+            return ticks > _time.GetUtcNow().UtcTicks ? new DateTime(ticks, DateTimeKind.Utc) : null;
+        }
+    }
+
+    public void EnableVerbose() =>
+        Volatile.Write(ref _verboseUntilUtcTicks, _time.GetUtcNow().Add(VerboseDuration).UtcTicks);
+
+    public void DisableVerbose() => Volatile.Write(ref _verboseUntilUtcTicks, 0);
+
+    public bool ShouldCapture(string category, LogLevel level)
+    {
+        if (level == LogLevel.None)
+        {
+            return false;
+        }
+
+        // EF Core below Warning is both noisy and a recursion hazard (queries issued while
+        // reading the log viewer would log themselves); never capture it, verbose or not.
+        if (category.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal))
+        {
+            return level >= LogLevel.Warning;
+        }
+
+        bool isApp = category.StartsWith("FairShare", StringComparison.Ordinal);
+        LogLevel minimum = VerboseEnabled
+            ? (isApp ? LogLevel.Debug : LogLevel.Information)
+            : (isApp ? LogLevel.Information : LogLevel.Warning);
+
+        return level >= minimum;
+    }
+}

--- a/src/FairShare.Api/Observability/LogSink.cs
+++ b/src/FairShare.Api/Observability/LogSink.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// Drains <see cref="SqliteLoggerProvider"/>'s channel and batch-inserts into the Logs table.
+/// Writes via raw Microsoft.Data.Sqlite on purpose: an EF write would emit EF log events and
+/// re-enter the logger. Failures fall back to stderr - the sink must never throw into the host.
+/// </summary>
+public sealed class LogSink(SqliteLoggerProvider provider, IConfiguration configuration) : BackgroundService
+{
+    private const int MaxBatchSize = 100;
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromSeconds(2);
+
+    private readonly ChannelReader<LogRow> _reader = provider.Reader;
+    private readonly string _connectionString = configuration.GetConnectionString("Default")
+        ?? throw new InvalidOperationException("Connection string not found.");
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        List<LogRow> batch = new(MaxBatchSize);
+
+        try
+        {
+            while (await _reader.WaitToReadAsync(stoppingToken))
+            {
+                // Give a burst a moment to accumulate so it lands as one transaction.
+                await Task.Delay(FlushInterval, stoppingToken);
+                DrainInto(batch);
+                Flush(batch);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown: fall through to the final drain below.
+        }
+
+        DrainInto(batch);
+        Flush(batch);
+    }
+
+    private void DrainInto(List<LogRow> batch)
+    {
+        while (batch.Count < MaxBatchSize * 10 && _reader.TryRead(out LogRow row))
+        {
+            batch.Add(row);
+        }
+    }
+
+    private void Flush(List<LogRow> batch)
+    {
+        if (batch.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            using SqliteConnection connection = new(_connectionString);
+            connection.Open();
+            using SqliteTransaction transaction = connection.BeginTransaction();
+            using SqliteCommand command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText =
+                "INSERT INTO Logs (OccurredAtUtc, Level, Category, Message, Exception) " +
+                "VALUES ($occurredAt, $level, $category, $message, $exception);";
+
+            SqliteParameter occurredAt = command.Parameters.Add("$occurredAt", SqliteType.Text);
+            SqliteParameter level = command.Parameters.Add("$level", SqliteType.Integer);
+            SqliteParameter category = command.Parameters.Add("$category", SqliteType.Text);
+            SqliteParameter message = command.Parameters.Add("$message", SqliteType.Text);
+            SqliteParameter exception = command.Parameters.Add("$exception", SqliteType.Text);
+
+            foreach (LogRow row in batch)
+            {
+                // Pass the DateTime itself: Microsoft.Data.Sqlite then stores the exact text
+                // format EF Core uses, so ordered comparisons (retention purge cutoffs) stay
+                // valid across rows written here and read through the EF entity.
+                occurredAt.Value = row.OccurredAtUtc;
+                level.Value = row.Level;
+                category.Value = row.Category;
+                message.Value = row.Message;
+                exception.Value = (object?)row.Exception ?? DBNull.Value;
+                command.ExecuteNonQuery();
+            }
+
+            transaction.Commit();
+        }
+        catch (Exception ex)
+        {
+            // stderr, not ILogger: logging a log-sink failure through the sink would loop.
+            Console.Error.WriteLine($"FairShare log sink flush failed ({batch.Count} rows dropped): {ex.Message}");
+        }
+        finally
+        {
+            batch.Clear();
+        }
+    }
+}

--- a/src/FairShare.Api/Observability/ObservabilityMaintenanceService.cs
+++ b/src/FairShare.Api/Observability/ObservabilityMaintenanceService.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// Nightly (00:20 UTC) rollup of raw analytics into the Daily* aggregates, plus retention
+/// purges: raw analytics 90 days, diagnostic logs 30 days, audit events 365 days. Catches up
+/// on startup (watermark = max DailySiteStats.Day), rolls each day idempotently
+/// (delete-then-insert in one transaction), and writes a DailySiteStats row even for
+/// zero-traffic days so the watermark always advances.
+/// </summary>
+public class ObservabilityMaintenanceService(
+    IServiceScopeFactory scopeFactory,
+    TimeProvider time,
+    ILogger<ObservabilityMaintenanceService> logger) : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+    private readonly TimeProvider _time = time;
+    private readonly ILogger<ObservabilityMaintenanceService> _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Small start delay so migration/seeding settles first (mirrors RefreshTokenCleanupService).
+        try
+        {
+            await Task.Delay(TimeSpan.FromMinutes(1), _time, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await RunOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Observability maintenance run failed; retrying at the next scheduled run.");
+            }
+
+            DateTime nowUtc = _time.GetUtcNow().UtcDateTime;
+            TimeSpan delay = AnalyticsRollup.NextRunUtc(nowUtc) - nowUtc;
+
+            try
+            {
+                await Task.Delay(delay, _time, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>One full maintenance pass. Public so tests can drive it directly.</summary>
+    public async Task RunOnceAsync(CancellationToken ct = default)
+    {
+        using IServiceScope scope = _scopeFactory.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+        DateOnly today = DateOnly.FromDateTime(_time.GetUtcNow().UtcDateTime);
+
+        DateOnly? watermark = await db.DailySiteStats.OrderByDescending(s => s.Day).Select(s => (DateOnly?)s.Day).FirstOrDefaultAsync(ct);
+        DateOnly? firstUnrolled = watermark?.AddDays(1) ?? await FindEarliestRawDayAsync(db, ct);
+
+        if (firstUnrolled is DateOnly start)
+        {
+            for (DateOnly day = start; day < today; day = day.AddDays(1))
+            {
+                await RollUpDayAsync(db, day, ct);
+            }
+        }
+
+        await PurgeAsync(db, today, ct);
+    }
+
+    private static async Task<DateOnly?> FindEarliestRawDayAsync(FairShareDbContext db, CancellationToken ct)
+    {
+        DateTime? earliestView = await db.PageViews.OrderBy(v => v.OccurredAtUtc).Select(v => (DateTime?)v.OccurredAtUtc).FirstOrDefaultAsync(ct);
+        DateTime? earliestEvent = await db.AnalyticsEvents.OrderBy(e => e.OccurredAtUtc).Select(e => (DateTime?)e.OccurredAtUtc).FirstOrDefaultAsync(ct);
+
+        DateTime? earliest = (earliestView, earliestEvent) switch
+        {
+            (null, null) => null,
+            (null, DateTime e) => e,
+            (DateTime v, null) => v,
+            (DateTime v, DateTime e) => v < e ? v : e
+        };
+
+        return earliest is DateTime dt ? DateOnly.FromDateTime(dt) : null;
+    }
+
+    private async Task RollUpDayAsync(FairShareDbContext db, DateOnly day, CancellationToken ct)
+    {
+        (DateTime startUtc, DateTime endUtc) = AnalyticsRollup.DayBounds(day);
+
+        List<PageView> views = await db.PageViews
+            .Where(v => v.OccurredAtUtc >= startUtc && v.OccurredAtUtc < endUtc)
+            .ToListAsync(ct);
+
+        List<AnalyticsEvent> events = await db.AnalyticsEvents
+            .Where(e => e.OccurredAtUtc >= startUtc && e.OccurredAtUtc < endUtc)
+            .ToListAsync(ct);
+
+        (DailySiteStat site, List<DailyRouteStat> routes, List<DailyReferrerStat> referrers, List<DailyEventStat> eventStats) =
+            AnalyticsRollup.ComputeDay(day, views, events);
+
+        // Idempotent per day: replace whatever a previous (possibly interrupted) run wrote.
+        using IDbContextTransaction transaction = await db.Database.BeginTransactionAsync(ct);
+
+        await db.DailySiteStats.Where(s => s.Day == day).ExecuteDeleteAsync(ct);
+        await db.DailyRouteStats.Where(s => s.Day == day).ExecuteDeleteAsync(ct);
+        await db.DailyReferrerStats.Where(s => s.Day == day).ExecuteDeleteAsync(ct);
+        await db.DailyEventStats.Where(s => s.Day == day).ExecuteDeleteAsync(ct);
+
+        db.DailySiteStats.Add(site);
+        db.DailyRouteStats.AddRange(routes);
+        db.DailyReferrerStats.AddRange(referrers);
+        db.DailyEventStats.AddRange(eventStats);
+
+        await db.SaveChangesAsync(ct);
+        await transaction.CommitAsync(ct);
+
+        _logger.LogInformation("Rolled up analytics for {Day}: {Views} views, {Visitors} visitors.", day, site.Views, site.Visitors);
+    }
+
+    private async Task PurgeAsync(FairShareDbContext db, DateOnly today, CancellationToken ct)
+    {
+        DateTime nowUtc = _time.GetUtcNow().UtcDateTime;
+        (DateTime todayStart, _) = AnalyticsRollup.DayBounds(today);
+
+        // Raw analytics are only purged once rolled up (never delete unrolled days).
+        DateTime rawCutoff = nowUtc - AnalyticsRollup.RawRetention;
+        if (rawCutoff > todayStart)
+        {
+            rawCutoff = todayStart;
+        }
+
+        int views = await db.PageViews.Where(v => v.OccurredAtUtc < rawCutoff).ExecuteDeleteAsync(ct);
+        int events = await db.AnalyticsEvents.Where(e => e.OccurredAtUtc < rawCutoff).ExecuteDeleteAsync(ct);
+        int logs = await db.Logs.Where(l => l.OccurredAtUtc < nowUtc - AnalyticsRollup.LogRetention).ExecuteDeleteAsync(ct);
+        int audits = await db.AuditEvents.Where(a => a.OccurredAtUtc < nowUtc - AnalyticsRollup.AuditRetention).ExecuteDeleteAsync(ct);
+
+        if (views + events + logs + audits > 0)
+        {
+            _logger.LogInformation(
+                "Retention purge removed {PageViews} page views, {Events} events, {Logs} log rows, {Audits} audit rows.",
+                views, events, logs, audits);
+        }
+    }
+}

--- a/src/FairShare.Api/Observability/SqliteLoggerProvider.cs
+++ b/src/FairShare.Api/Observability/SqliteLoggerProvider.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>A captured log call, queued for the batch writer.</summary>
+public readonly record struct LogRow(DateTime OccurredAtUtc, int Level, string Category, string Message, string? Exception);
+
+/// <summary>
+/// Hand-rolled provider persisting logs to the app's SQLite database (ADR 0003: no Serilog -
+/// the redaction and recursion guarantees live in code we own). Log calls enqueue into a
+/// bounded channel and never block or throw; <see cref="LogSink"/> drains it in batches.
+/// </summary>
+[ProviderAlias("Sqlite")]
+public sealed class SqliteLoggerProvider : ILoggerProvider
+{
+    // Bounded so a log storm degrades to dropped diagnostics, never to memory growth or
+    // request latency (NFR-4).
+    private readonly Channel<LogRow> _channel = Channel.CreateBounded<LogRow>(
+        new BoundedChannelOptions(2048)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true
+        });
+
+    private readonly LogLevelSwitch _levelSwitch;
+
+    public SqliteLoggerProvider(LogLevelSwitch levelSwitch)
+    {
+        _levelSwitch = levelSwitch;
+    }
+
+    /// <summary>Drained by <see cref="LogSink"/>; public so tests can observe captures.</summary>
+    public ChannelReader<LogRow> Reader => _channel.Reader;
+
+    public ILogger CreateLogger(string categoryName) => new SqliteLogger(categoryName, _levelSwitch, _channel.Writer);
+
+    public void Dispose() => _channel.Writer.TryComplete();
+
+    private sealed class SqliteLogger(string category, LogLevelSwitch levelSwitch, ChannelWriter<LogRow> writer) : ILogger
+    {
+        private readonly string _category = Truncate(category, LogEntry.MaxCategoryLength);
+        private readonly LogLevelSwitch _levelSwitch = levelSwitch;
+        private readonly ChannelWriter<LogRow> _writer = writer;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => _levelSwitch.ShouldCapture(_category, logLevel);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            string message;
+            try
+            {
+                message = formatter(state, exception);
+            }
+            catch
+            {
+                // A broken formatter must never take the request down with it.
+                message = state?.ToString() ?? string.Empty;
+            }
+
+            _writer.TryWrite(new LogRow(
+                DateTime.UtcNow,
+                (int)logLevel,
+                _category,
+                Truncate(message, LogEntry.MaxMessageLength),
+                exception is null ? null : Truncate(exception.ToString(), LogEntry.MaxExceptionLength)));
+        }
+
+        private static string Truncate(string value, int max) => value.Length <= max ? value : value[..max];
+    }
+}

--- a/src/FairShare.Api/Observability/VisitorKey.cs
+++ b/src/FairShare.Api/Observability/VisitorKey.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace FairShare.Api.Observability;
+
+/// <summary>
+/// Computes the anonymous daily visitor key: HMAC-SHA256 over the UTC date, IP, and
+/// user-agent. The date inside the payload makes keys unlinkable across days by design
+/// (glossary: "Daily visitor"); IP and UA are hash inputs only and are never stored.
+/// </summary>
+public static class VisitorKey
+{
+    public static string Compute(byte[] secret, DateOnly utcDay, string ip, string userAgent)
+    {
+        string payload = $"{utcDay:yyyy-MM-dd}\n{ip}\n{userAgent}";
+        byte[] hash = HMACSHA256.HashData(secret, Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexStringLower(hash);
+    }
+}

--- a/src/FairShare.Api/Persistence/FairShareDbContext.cs
+++ b/src/FairShare.Api/Persistence/FairShareDbContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using FairShare.Api.Models;
+using FairShare.Api.Observability;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -16,6 +17,15 @@ public class FairShareDbContext : IdentityDbContext<ApplicationUser, IdentityRol
 
     public DbSet<ParentProfile> ParentProfiles => Set<ParentProfile>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    public DbSet<LogEntry> Logs => Set<LogEntry>();
+    public DbSet<AuditEvent> AuditEvents => Set<AuditEvent>();
+    public DbSet<PageView> PageViews => Set<PageView>();
+    public DbSet<AnalyticsEvent> AnalyticsEvents => Set<AnalyticsEvent>();
+    public DbSet<AnalyticsState> AnalyticsStates => Set<AnalyticsState>();
+    public DbSet<DailySiteStat> DailySiteStats => Set<DailySiteStat>();
+    public DbSet<DailyRouteStat> DailyRouteStats => Set<DailyRouteStat>();
+    public DbSet<DailyReferrerStat> DailyReferrerStats => Set<DailyReferrerStat>();
+    public DbSet<DailyEventStat> DailyEventStats => Set<DailyEventStat>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -52,6 +62,77 @@ public class FairShareDbContext : IdentityDbContext<ApplicationUser, IdentityRol
              .WithMany()
              .HasForeignKey(p => p.OwnerUserId)
              .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<LogEntry>(b =>
+        {
+            b.HasKey(l => l.Id);
+            b.HasIndex(l => l.OccurredAtUtc);
+            b.Property(l => l.Category).HasMaxLength(LogEntry.MaxCategoryLength).IsRequired();
+            b.Property(l => l.Message).HasMaxLength(LogEntry.MaxMessageLength).IsRequired();
+            b.Property(l => l.Exception).HasMaxLength(LogEntry.MaxExceptionLength);
+        });
+
+        modelBuilder.Entity<AuditEvent>(b =>
+        {
+            b.HasKey(a => a.Id);
+            b.HasIndex(a => a.OccurredAtUtc);
+            b.Property(a => a.ActorName).HasMaxLength(AuditEvent.MaxActorNameLength);
+            b.Property(a => a.Action).HasMaxLength(AuditEvent.MaxActionLength).IsRequired();
+            b.Property(a => a.Target).HasMaxLength(AuditEvent.MaxTargetLength);
+            b.Property(a => a.Detail).HasMaxLength(AuditEvent.MaxDetailLength);
+        });
+
+        modelBuilder.Entity<PageView>(b =>
+        {
+            b.HasKey(v => v.Id);
+            b.HasIndex(v => v.OccurredAtUtc);
+            b.Property(v => v.Path).HasMaxLength(PageView.MaxPathLength).IsRequired();
+            b.Property(v => v.ReferrerHost).HasMaxLength(PageView.MaxReferrerHostLength);
+            b.Property(v => v.VisitorKey).HasMaxLength(PageView.MaxVisitorKeyLength).IsRequired();
+        });
+
+        modelBuilder.Entity<AnalyticsEvent>(b =>
+        {
+            b.HasKey(e => e.Id);
+            b.HasIndex(e => e.OccurredAtUtc);
+            b.Property(e => e.Name).HasMaxLength(AnalyticsEvent.MaxNameLength).IsRequired();
+            b.Property(e => e.Target).HasMaxLength(AnalyticsEvent.MaxTargetLength);
+            b.Property(e => e.VisitorKey).HasMaxLength(PageView.MaxVisitorKeyLength).IsRequired();
+        });
+
+        modelBuilder.Entity<AnalyticsState>(b =>
+        {
+            b.HasKey(s => s.Id);
+            b.Property(s => s.SecretBase64).HasMaxLength(64).IsRequired();
+        });
+
+        modelBuilder.Entity<DailySiteStat>(b =>
+        {
+            // Day is the primary key AND the rollup watermark (max Day = last completed day).
+            b.HasKey(s => s.Day);
+        });
+
+        modelBuilder.Entity<DailyRouteStat>(b =>
+        {
+            b.HasKey(s => s.Id);
+            b.Property(s => s.Path).HasMaxLength(PageView.MaxPathLength).IsRequired();
+            b.HasIndex(s => new { s.Day, s.Path }).IsUnique();
+        });
+
+        modelBuilder.Entity<DailyReferrerStat>(b =>
+        {
+            b.HasKey(s => s.Id);
+            b.Property(s => s.ReferrerHost).HasMaxLength(PageView.MaxReferrerHostLength).IsRequired();
+            b.HasIndex(s => new { s.Day, s.ReferrerHost }).IsUnique();
+        });
+
+        modelBuilder.Entity<DailyEventStat>(b =>
+        {
+            b.HasKey(s => s.Id);
+            b.Property(s => s.Name).HasMaxLength(AnalyticsEvent.MaxNameLength).IsRequired();
+            b.Property(s => s.Target).HasMaxLength(AnalyticsEvent.MaxTargetLength);
+            b.HasIndex(s => new { s.Day, s.Name });
         });
     }
 }

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -20,6 +20,8 @@ using FairShare.Api.Services;
 using FairShare.Api.Services.Export;
 using FairShare.Api.Options;
 using FairShare.Api.Middleware;
+using FairShare.Api.Observability;
+using Microsoft.Extensions.Logging;
 using FairShare.Domain.Interfaces;
 using FairShare.Domain.Calculators;
 using FairShare.Domain.Services;
@@ -220,6 +222,20 @@ builder.Services.AddScoped<IParentProfileService, ParentProfileService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<AdminSeeder>();
 builder.Services.AddHostedService<RefreshTokenCleanupService>();
+
+// Observability (ADR 0003): first-party log persistence, audit trail, and analytics.
+// The provider is registered through DI so the sink can share its channel instance;
+// appsettings gives the "Sqlite" alias a permissive framework filter and the
+// LogLevelSwitch does the real (runtime-adjustable) filtering.
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddSingleton<LogLevelSwitch>();
+builder.Services.AddSingleton<SqliteLoggerProvider>();
+builder.Services.AddSingleton<ILoggerProvider>(sp => sp.GetRequiredService<SqliteLoggerProvider>());
+builder.Services.AddHostedService<LogSink>();
+builder.Services.AddScoped<IAuditService, AuditService>();
+builder.Services.AddSingleton<AnalyticsSecretProvider>();
+builder.Services.AddScoped<IAnalyticsService, AnalyticsService>();
+builder.Services.AddHostedService<ObservabilityMaintenanceService>();
 
 var app = builder.Build();
 

--- a/src/FairShare.Api/appsettings.json
+++ b/src/FairShare.Api/appsettings.json
@@ -4,6 +4,11 @@
       "Default": "Warning",
       "Microsoft.AspNetCore": "Warning",
       "FairShare": "Information"
+    },
+    "Sqlite": {
+      "LogLevel": {
+        "Default": "Debug"
+      }
     }
   },
   "AllowedHosts": "*",

--- a/src/FairShare.Contracts/Observability/ObservabilityContracts.cs
+++ b/src/FairShare.Contracts/Observability/ObservabilityContracts.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace FairShare.Contracts.Observability;
+
+public class PageViewRequest
+{
+    [Required, MaxLength(300)]
+    public string Path { get; set; } = string.Empty;
+
+    // Only sent on the SPA's first load; route changes have no meaningful referrer.
+    [MaxLength(2000)]
+    public string? Referrer { get; set; }
+}
+
+public class ClientEventRequest
+{
+    [Required, MaxLength(40)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(300)]
+    public string? Target { get; set; }
+}
+
+public class StatsSummaryResponse
+{
+    public long PageViews { get; set; }
+    public long DailyVisitors { get; set; }
+    public long CalculationsCompleted { get; set; }
+    public long GatedHits { get; set; }
+    public long DonateClicks { get; set; }
+    public DateOnly? FirstDay { get; set; }
+}
+
+public class PageStatRow
+{
+    public string Path { get; set; } = string.Empty;
+    public long Views { get; set; }
+    public long Visitors { get; set; }
+}
+
+public class ReferrerStatRow
+{
+    public string ReferrerHost { get; set; } = string.Empty;
+    public long Views { get; set; }
+}
+
+public class EventStatRow
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Target { get; set; }
+    public long Count { get; set; }
+}
+
+public class LogEntryRow
+{
+    public long Id { get; set; }
+    public DateTime OccurredAtUtc { get; set; }
+    public string Level { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string? Exception { get; set; }
+}
+
+public class AuditEventRow
+{
+    public long Id { get; set; }
+    public DateTime OccurredAtUtc { get; set; }
+    public string? ActorName { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string? Target { get; set; }
+    public string? Detail { get; set; }
+}
+
+public class VerboseStatusResponse
+{
+    public bool Enabled { get; set; }
+    public DateTime? UntilUtc { get; set; }
+}
+
+public class VerboseRequest
+{
+    public bool Enabled { get; set; }
+}
+
+public class PagedResult<T>
+{
+    public List<T> Items { get; set; } = [];
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int TotalCount { get; set; }
+}

--- a/src/FairShare.Tests/Api/ObservabilityEndpointsTests.cs
+++ b/src/FairShare.Tests/Api/ObservabilityEndpointsTests.cs
@@ -1,0 +1,298 @@
+using System.Net.Http.Headers;
+using FairShare.Api.Observability;
+using FairShare.Api.Persistence;
+using FairShare.Contracts.Auth;
+using FairShare.Contracts.Calculation;
+using FairShare.Contracts.Observability;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class ObservabilityEndpointsTests : IClassFixture<FairShareApiFactory>
+{
+    private const string BrowserUa =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+    private readonly FairShareApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public ObservabilityEndpointsTests(FairShareApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+        // The bot filter treats a missing UA as a bot; tests impersonate a real browser.
+        _client.DefaultRequestHeaders.UserAgent.ParseAdd(BrowserUa);
+    }
+
+    // ---- Beacon: page views -------------------------------------------------------
+
+    [Fact]
+    public async Task PageViewBeacon_RecordsAnonymousRow()
+    {
+        int before = CountPageViews();
+
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            "api/v1/analytics/page-views",
+            new PageViewRequest { Path = "/states/al/cs42", Referrer = "https://www.google.com/search" });
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+        PageView row = db.PageViews.OrderByDescending(v => v.Id).First();
+
+        Assert.Equal(before + 1, db.PageViews.Count());
+        Assert.Equal("/states/al/cs42", row.Path);
+        Assert.Equal("www.google.com", row.ReferrerHost);
+        Assert.Equal(64, row.VisitorKey.Length);
+        // Nothing identifying is stored: the key is a hash, not the inputs.
+        Assert.DoesNotContain("Mozilla", row.VisitorKey);
+    }
+
+    [Fact]
+    public async Task PageViewBeacon_DoesNotRecord_WhenOptedOutBotOrUncountable()
+    {
+        int before = CountPageViews();
+
+        HttpRequestMessage dnt = new(HttpMethod.Post, "api/v1/analytics/page-views")
+        {
+            Content = JsonContent.Create(new PageViewRequest { Path = "/" })
+        };
+        dnt.Headers.Add("DNT", "1");
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.SendAsync(dnt)).StatusCode);
+
+        HttpRequestMessage bot = new(HttpMethod.Post, "api/v1/analytics/page-views")
+        {
+            Content = JsonContent.Create(new PageViewRequest { Path = "/" })
+        };
+        bot.Headers.UserAgent.ParseAdd("Googlebot/2.1");
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.SendAsync(bot)).StatusCode);
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await _client.PostAsJsonAsync("api/v1/analytics/page-views", new PageViewRequest { Path = "/admin/stats" })).StatusCode);
+
+        Assert.Equal(before, CountPageViews());
+    }
+
+    [Fact]
+    public async Task PageViewBeacon_DoesNotRecordAdminsOwnBrowsing()
+    {
+        int before = CountPageViews();
+        string adminToken = await LoginAsAdminAsync();
+
+        HttpRequestMessage request = new(HttpMethod.Post, "api/v1/analytics/page-views")
+        {
+            Content = JsonContent.Create(new PageViewRequest { Path = "/" })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, (await _client.SendAsync(request)).StatusCode);
+        Assert.Equal(before, CountPageViews());
+    }
+
+    // ---- Beacon: client events ----------------------------------------------------
+
+    [Fact]
+    public async Task EventBeacon_AcceptsGatedHit_ButNeverServerEventNames()
+    {
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await _client.PostAsJsonAsync("api/v1/analytics/events", new ClientEventRequest { Name = "gated-hit", Target = "profiles" })).StatusCode);
+
+        Assert.Equal(HttpStatusCode.NoContent,
+            (await _client.PostAsJsonAsync("api/v1/analytics/events", new ClientEventRequest { Name = "calculation-completed", Target = "al/cs42" })).StatusCode);
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+        Assert.Equal(1, db.AnalyticsEvents.Count(e => e.Name == "gated-hit" && e.Target == "profiles"));
+        // The forged server event must not exist (calculations record it server-side only).
+        Assert.Equal(0, db.AnalyticsEvents.Count(e => e.Name == "calculation-completed"));
+    }
+
+    // ---- Server events from calculations ------------------------------------------
+
+    [Fact]
+    public async Task Calculation_RecordsStartedAndCompletedEvents_ForGuests()
+    {
+        string guestToken = await StartGuestAsync();
+
+        HttpRequestMessage request = new(HttpMethod.Post, "api/v1/states/AL/forms/CS42/calculations")
+        {
+            Content = JsonContent.Create(new CalculationRequest
+            {
+                NumberOfChildren = 1,
+                Plaintiff = new ParentDataDto { MonthlyGrossIncome = 1200, HealthcareCoverageCosts = 100, HasPrimaryCustody = true },
+                Defendant = new ParentDataDto { MonthlyGrossIncome = 1000, WorkRelatedChildcareCosts = 20 }
+            })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", guestToken);
+
+        HttpResponseMessage response = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+        Assert.Equal(1, db.AnalyticsEvents.Count(e => e.Name == "calculation-started" && e.Target == "al/cs42"));
+        Assert.Equal(1, db.AnalyticsEvents.Count(e => e.Name == "calculation-completed" && e.Target == "al/cs42"));
+    }
+
+    // ---- Admin endpoints: auth and behavior ----------------------------------------
+
+    [Fact]
+    public async Task AdminObservabilityEndpoints_RequireAdmin()
+    {
+        string guestToken = await StartGuestAsync();
+
+        foreach (string route in new[]
+                 {
+                     "api/v1/admin/stats/summary", "api/v1/admin/stats/pages", "api/v1/admin/stats/referrers",
+                     "api/v1/admin/stats/events", "api/v1/admin/logs", "api/v1/admin/logs/audit", "api/v1/admin/logs/verbose"
+                 })
+        {
+            Assert.Equal(HttpStatusCode.Unauthorized, (await _client.GetAsync(route)).StatusCode);
+
+            HttpRequestMessage asGuest = new(HttpMethod.Get, route);
+            asGuest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", guestToken);
+            Assert.Equal(HttpStatusCode.Forbidden, (await _client.SendAsync(asGuest)).StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task StatsSummary_ReflectsRecordedActivity()
+    {
+        await _client.PostAsJsonAsync("api/v1/analytics/page-views", new PageViewRequest { Path = "/summary-check" });
+
+        string adminToken = await LoginAsAdminAsync();
+        HttpRequestMessage request = new(HttpMethod.Get, "api/v1/admin/stats/summary?days=7");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+        HttpResponseMessage response = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        StatsSummaryResponse summary = (await response.Content.ReadFromJsonAsync<StatsSummaryResponse>())!;
+        Assert.True(summary.PageViews >= 1);
+        Assert.True(summary.DailyVisitors >= 1);
+    }
+
+    [Fact]
+    public async Task VerboseToggle_RoundTrips_AndIsAudited()
+    {
+        string adminToken = await LoginAsAdminAsync();
+
+        HttpRequestMessage enable = new(HttpMethod.Put, "api/v1/admin/logs/verbose")
+        {
+            Content = JsonContent.Create(new VerboseRequest { Enabled = true })
+        };
+        enable.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+        HttpResponseMessage enableResponse = await _client.SendAsync(enable);
+        Assert.Equal(HttpStatusCode.OK, enableResponse.StatusCode);
+        VerboseStatusResponse status = (await enableResponse.Content.ReadFromJsonAsync<VerboseStatusResponse>())!;
+        Assert.True(status.Enabled);
+        Assert.NotNull(status.UntilUtc);
+
+        HttpRequestMessage disable = new(HttpMethod.Put, "api/v1/admin/logs/verbose")
+        {
+            Content = JsonContent.Create(new VerboseRequest { Enabled = false })
+        };
+        disable.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+        VerboseStatusResponse offStatus = (await (await _client.SendAsync(disable)).Content.ReadFromJsonAsync<VerboseStatusResponse>())!;
+        Assert.False(offStatus.Enabled);
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+        Assert.True(db.AuditEvents.Any(a => a.Action == AuditActions.VerboseEnabled && a.ActorName == "admin"));
+        Assert.True(db.AuditEvents.Any(a => a.Action == AuditActions.VerboseDisabled && a.ActorName == "admin"));
+    }
+
+    [Fact]
+    public async Task FailedLogin_WritesAuditEvent()
+    {
+        await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest { UserName = "admin", Password = "wrong-password-1" });
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+        Assert.True(db.AuditEvents.Any(a => a.Action == AuditActions.LoginFailed && a.Target == "admin"));
+    }
+
+    // ---- Maintenance: rollup + retention -------------------------------------------
+
+    [Fact]
+    public async Task Maintenance_RollsUpCompletedDays_AndPurgesExpiredRows()
+    {
+        DateTime nowUtc = DateTime.UtcNow;
+        DateOnly yesterday = DateOnly.FromDateTime(nowUtc).AddDays(-1);
+        DateTime yesterdayNoon = yesterday.ToDateTime(new TimeOnly(12, 0), DateTimeKind.Utc);
+
+        using (IServiceScope seedScope = _factory.Services.CreateScope())
+        {
+            FairShareDbContext db = seedScope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+            db.PageViews.Add(new PageView { Path = "/", VisitorKey = "k1", OccurredAtUtc = yesterdayNoon });
+            db.PageViews.Add(new PageView { Path = "/", VisitorKey = "k2", OccurredAtUtc = yesterdayNoon });
+            db.AnalyticsEvents.Add(new AnalyticsEvent { Name = "gated-hit", Target = "profiles", VisitorKey = "k1", OccurredAtUtc = yesterdayNoon });
+            db.Logs.Add(new LogEntry { OccurredAtUtc = nowUtc.AddDays(-40), Level = 2, Category = "FairShare.Old", Message = "expired" });
+            db.Logs.Add(new LogEntry { OccurredAtUtc = nowUtc, Level = 2, Category = "FairShare.New", Message = "fresh" });
+            db.AuditEvents.Add(new AuditEvent { OccurredAtUtc = nowUtc.AddDays(-400), Action = "login-succeeded", ActorName = "ancient" });
+            await db.SaveChangesAsync();
+        }
+
+        ObservabilityMaintenanceService maintenance = new(
+            _factory.Services.GetRequiredService<IServiceScopeFactory>(),
+            TimeProvider.System,
+            NullLogger<ObservabilityMaintenanceService>.Instance);
+
+        await maintenance.RunOnceAsync();
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext verify = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+
+        DailySiteStat site = verify.DailySiteStats.Single(s => s.Day == yesterday);
+        Assert.Equal(2, site.Views);
+        Assert.Equal(2, site.Visitors);
+        Assert.Equal(1, verify.DailyEventStats.Count(e => e.Day == yesterday && e.Name == "gated-hit"));
+
+        Assert.False(verify.Logs.Any(l => l.Category == "FairShare.Old"), "30-day log retention should have purged the old row");
+        Assert.True(verify.Logs.Any(l => l.Category == "FairShare.New"));
+        Assert.False(verify.AuditEvents.Any(a => a.ActorName == "ancient"), "365-day audit retention should have purged the old row");
+
+        // Idempotent: a second run must not double the aggregates.
+        await maintenance.RunOnceAsync();
+        using IServiceScope secondScope = _factory.Services.CreateScope();
+        FairShareDbContext verifyAgain = secondScope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+        Assert.Equal(2, verifyAgain.DailySiteStats.Single(s => s.Day == yesterday).Views);
+    }
+
+    // ---- Helpers -------------------------------------------------------------------
+
+    private int CountPageViews()
+    {
+        using IServiceScope scope = _factory.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<FairShareDbContext>().PageViews.Count();
+    }
+
+    private async Task<string> LoginAsAdminAsync()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = "admin",
+            Password = "Adm!n-Test-12345"
+        });
+
+        AuthTokenResponse tokens = (await response.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+        return tokens.AccessToken;
+    }
+
+    private async Task<string> StartGuestAsync()
+    {
+        HttpResponseMessage response = await _client.PostAsync("api/v1/auth/guest", content: null);
+        AuthTokenResponse tokens = (await response.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+        return tokens.AccessToken;
+    }
+}

--- a/src/FairShare.Tests/Observability/AnalyticsRollupTests.cs
+++ b/src/FairShare.Tests/Observability/AnalyticsRollupTests.cs
@@ -1,0 +1,85 @@
+using FairShare.Api.Observability;
+
+namespace FairShare.Tests.Observability;
+
+public class AnalyticsRollupTests
+{
+    private static readonly DateOnly Day = new(2026, 8, 19);
+
+    private static PageView View(string path, string visitor, string? referrer = null) =>
+        new() { Path = path, VisitorKey = visitor, ReferrerHost = referrer, OccurredAtUtc = Day.ToDateTime(new TimeOnly(10, 0), DateTimeKind.Utc) };
+
+    private static AnalyticsEvent Event(string name, string? target, string visitor) =>
+        new() { Name = name, Target = target, VisitorKey = visitor, OccurredAtUtc = Day.ToDateTime(new TimeOnly(10, 0), DateTimeKind.Utc) };
+
+    [Fact]
+    public void ComputeDay_AggregatesViewsVisitorsRoutesReferrersAndEvents()
+    {
+        List<PageView> views =
+        [
+            View("/", "a", "www.google.com"),
+            View("/", "a"),
+            View("/states/al/cs42", "a"),
+            View("/states/al/cs42", "b", "www.google.com"),
+            View("/states/al/cs42", "b", "duckduckgo.com")
+        ];
+
+        List<AnalyticsEvent> events =
+        [
+            Event("calculation-completed", "al/cs42", "a"),
+            Event("calculation-completed", "al/cs42", "b"),
+            Event("gated-hit", "profiles", "b")
+        ];
+
+        (DailySiteStat site, List<DailyRouteStat> routes, List<DailyReferrerStat> referrers, List<DailyEventStat> eventStats) =
+            AnalyticsRollup.ComputeDay(Day, views, events);
+
+        Assert.Equal(5, site.Views);
+        Assert.Equal(2, site.Visitors);
+
+        DailyRouteStat calc = Assert.Single(routes, r => r.Path == "/states/al/cs42");
+        Assert.Equal(3, calc.Views);
+        Assert.Equal(2, calc.Visitors);
+
+        DailyReferrerStat google = Assert.Single(referrers, r => r.ReferrerHost == "www.google.com");
+        Assert.Equal(2, google.Views);
+
+        DailyEventStat completed = Assert.Single(eventStats, e => e.Name == "calculation-completed");
+        Assert.Equal(2, completed.Count);
+        Assert.Equal("al/cs42", completed.Target);
+    }
+
+    [Fact]
+    public void ComputeDay_ZeroTraffic_StillProducesTheWatermarkRow()
+    {
+        (DailySiteStat site, List<DailyRouteStat> routes, List<DailyReferrerStat> referrers, List<DailyEventStat> events) =
+            AnalyticsRollup.ComputeDay(Day, [], []);
+
+        Assert.Equal(Day, site.Day);
+        Assert.Equal(0, site.Views);
+        Assert.Empty(routes);
+        Assert.Empty(referrers);
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void DayBounds_AreUtcKind()
+    {
+        // Regression guard from Portfolio: DateOnly.ToDateTime defaults to Kind=Unspecified,
+        // which timestamptz-style providers reject.
+        (DateTime start, DateTime end) = AnalyticsRollup.DayBounds(Day);
+
+        Assert.Equal(DateTimeKind.Utc, start.Kind);
+        Assert.Equal(DateTimeKind.Utc, end.Kind);
+        Assert.Equal(TimeSpan.FromDays(1), end - start);
+    }
+
+    [Theory]
+    [InlineData("2026-08-20T00:00:00Z", "2026-08-20T00:20:00Z")] // before today's run -> today
+    [InlineData("2026-08-20T00:20:00Z", "2026-08-21T00:20:00Z")] // at the run time -> tomorrow
+    [InlineData("2026-08-20T13:00:00Z", "2026-08-21T00:20:00Z")] // after -> tomorrow
+    public void NextRunUtc_TargetsTwentyPastMidnightUtc(string now, string expected) =>
+        Assert.Equal(
+            DateTime.Parse(expected, null, System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal),
+            AnalyticsRollup.NextRunUtc(DateTime.Parse(now, null, System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal)));
+}

--- a/src/FairShare.Tests/Observability/AnalyticsRulesTests.cs
+++ b/src/FairShare.Tests/Observability/AnalyticsRulesTests.cs
@@ -1,0 +1,113 @@
+using FairShare.Api.Observability;
+using Microsoft.AspNetCore.Http;
+
+namespace FairShare.Tests.Observability;
+
+public class AnalyticsRulesTests
+{
+    private const string RealBrowserUa =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Googlebot/2.1 (+http://www.google.com/bot.html)")]
+    [InlineData("Mozilla/5.0 (compatible; bingbot/2.0)")]
+    [InlineData("curl/8.4.0")]
+    [InlineData("python-requests/2.31")]
+    [InlineData("HeadlessChrome/120.0")]
+    [InlineData("UptimeMonitor/1.0")]
+    public void IsBot_FlagsNonBrowsers(string? userAgent) => Assert.True(AnalyticsRules.IsBot(userAgent));
+
+    [Fact]
+    public void IsBot_AllowsRealBrowser() => Assert.False(AnalyticsRules.IsBot(RealBrowserUa));
+
+    [Theory]
+    [InlineData("1", null, true)]
+    [InlineData(null, "1", true)]
+    [InlineData("1", "1", true)]
+    [InlineData(null, null, false)]
+    [InlineData("0", null, false)]
+    public void OptedOut_HonorsDntAndGpc(string? dnt, string? gpc, bool expected)
+    {
+        HeaderDictionary headers = [];
+        if (dnt is not null)
+        {
+            headers["DNT"] = dnt;
+        }
+
+        if (gpc is not null)
+        {
+            headers["Sec-GPC"] = gpc;
+        }
+
+        Assert.Equal(expected, AnalyticsRules.OptedOut(headers));
+    }
+
+    [Theory]
+    [InlineData("/", "/")]
+    [InlineData("/States/AL/CS42", "/states/al/cs42")]
+    [InlineData("/states/al/", "/states/al")]
+    [InlineData("/profiles?tab=2", "/profiles")]
+    [InlineData("/profiles#section", "/profiles")]
+    public void TryNormalizePath_AcceptsAndNormalizesRoutes(string raw, string expected)
+    {
+        Assert.True(AnalyticsRules.TryNormalizePath(raw, out string normalized));
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("no-leading-slash")]
+    [InlineData("//protocol-relative")]
+    [InlineData("/admin")]
+    [InlineData("/admin/stats")]
+    [InlineData("/login")]
+    [InlineData("/register")]
+    [InlineData("/account/change-password")]
+    [InlineData("/go/donate")]
+    [InlineData("/healthz")]
+    [InlineData("/api/v1/parents")]
+    [InlineData("/_framework/blazor.webassembly.js")]
+    [InlineData("/favicon.ico")]
+    [InlineData("/feed.xml")]
+    public void TryNormalizePath_RejectsUncountablePaths(string? raw) =>
+        Assert.False(AnalyticsRules.TryNormalizePath(raw, out _));
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("not a url", null)]
+    [InlineData("https://www.google.com/search?q=cs42", "www.google.com")]
+    [InlineData("https://EXAMPLE.org/page", "example.org")]
+    public void NormalizeReferrer_KeepsExternalHostOnly(string? referrer, string? expected) =>
+        Assert.Equal(expected, AnalyticsRules.NormalizeReferrer(referrer, "easychildsupport.fyi"));
+
+    [Fact]
+    public void NormalizeReferrer_DropsInternalReferrals() =>
+        Assert.Null(AnalyticsRules.NormalizeReferrer("https://easychildsupport.fyi/states/al", "easychildsupport.fyi"));
+
+    [Theory]
+    [InlineData("gated-hit", "profiles", true)]
+    [InlineData("Gated-Hit", "PROFILES", true)]
+    [InlineData("gated-hit", null, true)]
+    public void TryNormalizeClientEvent_AcceptsWhitelistedEvents(string name, string? target, bool expected)
+    {
+        Assert.Equal(expected, AnalyticsRules.TryNormalizeClientEvent(name, target, out string normalizedName, out string? normalizedTarget));
+        Assert.Equal("gated-hit", normalizedName);
+        Assert.Equal(target?.ToLowerInvariant(), normalizedTarget);
+    }
+
+    [Theory]
+    [InlineData("calculation-completed", null)] // server-observed events cannot be forged by clients
+    [InlineData("donate-click", null)]
+    [InlineData("custom-event", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    [InlineData("gated-hit", "income $4,200")] // free text can smuggle case content - refused
+    [InlineData("gated-hit", "UPPER CASE SPACES")]
+    public void TryNormalizeClientEvent_RejectsForgeriesAndFreeText(string? name, string? target) =>
+        Assert.False(AnalyticsRules.TryNormalizeClientEvent(name, target, out _, out _));
+}

--- a/src/FairShare.Tests/Observability/FakeTimeProvider.cs
+++ b/src/FairShare.Tests/Observability/FakeTimeProvider.cs
@@ -1,0 +1,11 @@
+namespace FairShare.Tests.Observability;
+
+/// <summary>Minimal controllable clock for switch/rollup tests.</summary>
+public class FakeTimeProvider(DateTimeOffset start) : TimeProvider
+{
+    public DateTimeOffset UtcNow { get; set; } = start;
+
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+
+    public void Advance(TimeSpan by) => UtcNow += by;
+}

--- a/src/FairShare.Tests/Observability/LogLevelSwitchTests.cs
+++ b/src/FairShare.Tests/Observability/LogLevelSwitchTests.cs
@@ -1,0 +1,82 @@
+using FairShare.Api.Observability;
+using Microsoft.Extensions.Logging;
+
+namespace FairShare.Tests.Observability;
+
+public class LogLevelSwitchTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 8, 20, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Normal_CapturesAppInformationButNotDebug()
+    {
+        LogLevelSwitch sw = new(new FakeTimeProvider(Start));
+
+        Assert.True(sw.ShouldCapture("FairShare.Api.Controllers.AuthController", LogLevel.Information));
+        Assert.False(sw.ShouldCapture("FairShare.Api.Controllers.AuthController", LogLevel.Debug));
+        Assert.True(sw.ShouldCapture("Microsoft.AspNetCore.Hosting", LogLevel.Warning));
+        Assert.False(sw.ShouldCapture("Microsoft.AspNetCore.Hosting", LogLevel.Information));
+    }
+
+    [Fact]
+    public void Verbose_CapturesAppDebugAndFrameworkInformation()
+    {
+        LogLevelSwitch sw = new(new FakeTimeProvider(Start));
+        sw.EnableVerbose();
+
+        Assert.True(sw.VerboseEnabled);
+        Assert.NotNull(sw.VerboseUntilUtc);
+        Assert.True(sw.ShouldCapture("FairShare.Api.Observability.AnalyticsService", LogLevel.Debug));
+        Assert.True(sw.ShouldCapture("Microsoft.AspNetCore.Hosting", LogLevel.Information));
+    }
+
+    [Fact]
+    public void Verbose_AlwaysTurnsItselfBackOff()
+    {
+        FakeTimeProvider time = new(Start);
+        LogLevelSwitch sw = new(time);
+        sw.EnableVerbose();
+
+        time.Advance(LogLevelSwitch.VerboseDuration + TimeSpan.FromMinutes(1));
+
+        Assert.False(sw.VerboseEnabled);
+        Assert.Null(sw.VerboseUntilUtc);
+        Assert.False(sw.ShouldCapture("FairShare.Api.X", LogLevel.Debug));
+    }
+
+    [Fact]
+    public void Verbose_CanBeDisabledManually()
+    {
+        LogLevelSwitch sw = new(new FakeTimeProvider(Start));
+        sw.EnableVerbose();
+        sw.DisableVerbose();
+
+        Assert.False(sw.VerboseEnabled);
+    }
+
+    [Fact]
+    public void EfCoreCategories_NeverCaptureBelowWarning_EvenVerbose()
+    {
+        LogLevelSwitch sw = new(new FakeTimeProvider(Start));
+        sw.EnableVerbose();
+
+        Assert.False(sw.ShouldCapture("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Information));
+        Assert.True(sw.ShouldCapture("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning));
+    }
+
+    [Fact]
+    public void Provider_CapturesThroughSwitchAndTruncates()
+    {
+        LogLevelSwitch sw = new(new FakeTimeProvider(Start));
+        using SqliteLoggerProvider provider = new(sw);
+        ILogger logger = provider.CreateLogger("FairShare.Tests.Sample");
+
+        logger.LogDebug("dropped in normal mode");
+        logger.LogInformation("kept {Value}", new string('x', 5000));
+
+        Assert.True(provider.Reader.TryRead(out LogRow row));
+        Assert.Equal((int)LogLevel.Information, row.Level);
+        Assert.Equal(LogEntry.MaxMessageLength, row.Message.Length);
+        Assert.False(provider.Reader.TryRead(out _));
+    }
+}

--- a/src/FairShare.Tests/Observability/VisitorKeyTests.cs
+++ b/src/FairShare.Tests/Observability/VisitorKeyTests.cs
@@ -1,0 +1,52 @@
+using FairShare.Api.Observability;
+
+namespace FairShare.Tests.Observability;
+
+public class VisitorKeyTests
+{
+    private static readonly byte[] Secret = new byte[32];
+    private const string Ip = "203.0.113.7";
+    private const string Ua = "Mozilla/5.0 test";
+
+    [Fact]
+    public void Compute_IsDeterministicWithinOneDay()
+    {
+        DateOnly day = new(2026, 8, 20);
+
+        Assert.Equal(
+            VisitorKey.Compute(Secret, day, Ip, Ua),
+            VisitorKey.Compute(Secret, day, Ip, Ua));
+    }
+
+    [Fact]
+    public void Compute_ChangesAcrossDays_SoVisitorsAreUnlinkable()
+    {
+        Assert.NotEqual(
+            VisitorKey.Compute(Secret, new DateOnly(2026, 8, 20), Ip, Ua),
+            VisitorKey.Compute(Secret, new DateOnly(2026, 8, 21), Ip, Ua));
+    }
+
+    [Fact]
+    public void Compute_ChangesWithIpUaAndSecret()
+    {
+        DateOnly day = new(2026, 8, 20);
+        string baseline = VisitorKey.Compute(Secret, day, Ip, Ua);
+
+        byte[] otherSecret = new byte[32];
+        otherSecret[0] = 1;
+
+        Assert.NotEqual(baseline, VisitorKey.Compute(Secret, day, "203.0.113.8", Ua));
+        Assert.NotEqual(baseline, VisitorKey.Compute(Secret, day, Ip, "Mozilla/5.0 other"));
+        Assert.NotEqual(baseline, VisitorKey.Compute(otherSecret, day, Ip, Ua));
+    }
+
+    [Fact]
+    public void Compute_ProducesLowercaseHexWithinColumnLimit()
+    {
+        string key = VisitorKey.Compute(Secret, new DateOnly(2026, 8, 20), Ip, Ua);
+
+        Assert.Equal(64, key.Length);
+        Assert.Equal(key, key.ToLowerInvariant());
+        Assert.All(key, c => Assert.True(char.IsAsciiDigit(c) || (c >= 'a' && c <= 'f')));
+    }
+}

--- a/src/FairShare.Web/App.razor
+++ b/src/FairShare.Web/App.razor
@@ -4,7 +4,13 @@
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
             <NotAuthorized>
-                @if (context.User.Identity?.IsAuthenticated == true)
+                @if (context.User.HasClaim("guest", "true"))
+                {
+                    @* A guest on a users-only page is a would-be convert, not an intruder:
+                       invite the sign-in (and count the gated hit) instead of denying. *@
+                    <GatedSignInPrompt />
+                }
+                else if (context.User.Identity?.IsAuthenticated == true)
                 {
                     @* Signed in but lacking the required role/policy (e.g. non-admin on
                        /admin/users) - bouncing to /login would be misleading. *@

--- a/src/FairShare.Web/Components/GatedSignInPrompt.razor
+++ b/src/FairShare.Web/Components/GatedSignInPrompt.razor
@@ -1,0 +1,23 @@
+@inject NavigationManager Navigation
+@inject FairShare.Web.Services.AnalyticsBeacon Beacon
+
+@* Shown when a guest lands on a users-only page. This is the conversion moment, so it is
+   also where the anonymous gated-hit signal is recorded (ADR 0003). *@
+<div class="container my-5 text-center">
+    <h3>Sign in to use this feature</h3>
+    <p class="text-muted mb-1">Saving and managing parent profiles needs a free account.</p>
+    <p class="text-muted">Nothing you have typed is stored unless you choose to save it.</p>
+    <a class="btn btn-primary" href="@LoginHref">Sign in</a>
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        string relative = Navigation.ToBaseRelativePath(Navigation.Uri);
+        string gate = relative.Split('?', '#')[0].Trim('/').Split('/')[0].ToLowerInvariant();
+        await Beacon.TrackGatedHitAsync(gate.Length == 0 ? "home" : gate);
+    }
+
+    private string LoginHref =>
+        $"login?returnUrl={Uri.EscapeDataString("/" + Navigation.ToBaseRelativePath(Navigation.Uri))}";
+}

--- a/src/FairShare.Web/Components/Pager.razor
+++ b/src/FairShare.Web/Components/Pager.razor
@@ -1,0 +1,18 @@
+@* Previous/next pager shared by the admin log and audit tables. *@
+@if (TotalPages > 1)
+{
+    <nav aria-label="Pagination" class="d-flex gap-2 align-items-center">
+        <button class="btn btn-sm btn-outline-secondary" disabled="@(Page <= 1)" @onclick="() => OnChange.InvokeAsync(Page - 1)">Previous</button>
+        <span class="small text-muted">Page @Page of @TotalPages</span>
+        <button class="btn btn-sm btn-outline-secondary" disabled="@(Page >= TotalPages)" @onclick="() => OnChange.InvokeAsync(Page + 1)">Next</button>
+    </nav>
+}
+
+@code {
+    [Parameter, EditorRequired] public int Page { get; set; }
+    [Parameter, EditorRequired] public int TotalCount { get; set; }
+    [Parameter, EditorRequired] public int PageSize { get; set; }
+    [Parameter] public EventCallback<int> OnChange { get; set; }
+
+    private int TotalPages => Math.Max(1, (TotalCount + PageSize - 1) / PageSize);
+}

--- a/src/FairShare.Web/Components/StatTile.razor
+++ b/src/FairShare.Web/Components/StatTile.razor
@@ -1,0 +1,14 @@
+@* One number-with-label card for the admin stats page. *@
+<div class="col-6 col-md-4 col-xl">
+    <div class="card text-center h-100">
+        <div class="card-body py-3">
+            <div class="fs-3 fw-semibold">@Value</div>
+            <div class="text-muted small">@Label</div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Label { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public long Value { get; set; }
+}

--- a/src/FairShare.Web/Layout/NavMenu.razor
+++ b/src/FairShare.Web/Layout/NavMenu.razor
@@ -26,6 +26,12 @@
                             <li class="nav-item">
                                 <NavLink class="nav-link" href="admin/users">Admin</NavLink>
                             </li>
+                            <li class="nav-item">
+                                <NavLink class="nav-link" href="admin/stats">Stats</NavLink>
+                            </li>
+                            <li class="nav-item">
+                                <NavLink class="nav-link" href="admin/logs">Logs</NavLink>
+                            </li>
                         }
                     </Authorized>
                 </AuthorizeView>

--- a/src/FairShare.Web/Pages/Admin/Logs.razor
+++ b/src/FairShare.Web/Pages/Admin/Logs.razor
@@ -46,6 +46,7 @@
                 <option value="Error">Error+</option>
             </select>
             <input class="form-control" style="max-width: 20rem;" placeholder="Search message or category"
+                   aria-label="Search message or category"
                    @bind="search" @bind:event="oninput" @onkeydown="OnSearchKeyDown" />
             <button class="btn btn-outline-secondary" @onclick="ReloadAsync">Search</button>
         </div>
@@ -166,8 +167,10 @@
                     $"api/v1/admin/logs?page={page}&pageSize={PageSize}&level={Uri.EscapeDataString(level)}&search={Uri.EscapeDataString(search)}");
             }
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
+            // Also JsonException/NotSupportedException: an expired session can answer with
+            // non-JSON, and the page must degrade to the banner rather than crash.
             loadFailed = true;
         }
     }
@@ -178,7 +181,7 @@
         {
             verbose = await Http.GetFromJsonAsync<VerboseStatusResponse>("api/v1/admin/logs/verbose");
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
             loadFailed = true;
         }
@@ -195,7 +198,7 @@
                 verbose = await response.Content.ReadFromJsonAsync<VerboseStatusResponse>();
             }
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
             loadFailed = true;
         }

--- a/src/FairShare.Web/Pages/Admin/Logs.razor
+++ b/src/FairShare.Web/Pages/Admin/Logs.razor
@@ -1,0 +1,232 @@
+@page "/admin/logs"
+@using FairShare.Contracts.Observability
+@attribute [Authorize(Policy = "AdminOnly")]
+@inject HttpClient Http
+
+<PageTitle>FairShare - Logs</PageTitle>
+
+<div class="container my-4">
+    <div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+        <h2 class="mb-0">Logs</h2>
+
+        <div class="form-check form-switch ms-auto" title="Captures Debug detail for ~4 hours, then reverts on its own.">
+            <input class="form-check-input" type="checkbox" role="switch" id="verboseSwitch"
+                   checked="@(verbose?.Enabled == true)" @onchange="ToggleVerboseAsync" />
+            <label class="form-check-label" for="verboseSwitch">
+                Verbose
+                @if (verbose is { Enabled: true, UntilUtc: DateTime until })
+                {
+                    <span class="text-muted small">(until @until.ToLocalTime().ToString("t"))</span>
+                }
+            </label>
+        </div>
+    </div>
+
+    <ul class="nav nav-pills mb-3">
+        <li class="nav-item">
+            <button class="nav-link @(showAudit ? "" : "active")" @onclick="() => SwitchTabAsync(false)">Diagnostics</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link @(showAudit ? "active" : "")" @onclick="() => SwitchTabAsync(true)">Audit</button>
+        </li>
+    </ul>
+
+    @if (loadFailed)
+    {
+        <div class="alert alert-warning" role="alert">Could not load logs. Try again shortly.</div>
+    }
+    else if (!showAudit)
+    {
+        <div class="d-flex gap-2 mb-3 flex-wrap">
+            <select @bind="level" @bind:after="ReloadAsync" class="form-select" style="width: auto;" aria-label="Minimum level">
+                <option value="">All levels</option>
+                <option value="Debug">Debug+</option>
+                <option value="Information">Information+</option>
+                <option value="Warning">Warning+</option>
+                <option value="Error">Error+</option>
+            </select>
+            <input class="form-control" style="max-width: 20rem;" placeholder="Search message or category"
+                   @bind="search" @bind:event="oninput" @onkeydown="OnSearchKeyDown" />
+            <button class="btn btn-outline-secondary" @onclick="ReloadAsync">Search</button>
+        </div>
+
+        @if (logs is null)
+        {
+            <p>Loading...</p>
+        }
+        else if (logs.Items.Count == 0)
+        {
+            <p class="text-muted">No log entries match.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-striped table-sm align-middle">
+                    <thead>
+                        <tr><th>Time</th><th>Level</th><th>Category</th><th>Message</th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (LogEntryRow row in logs.Items)
+                        {
+                            <tr>
+                                <td class="text-nowrap">@row.OccurredAtUtc.ToLocalTime().ToString("g")</td>
+                                <td><span class="badge @LevelBadge(row.Level)">@row.Level</span></td>
+                                <td class="small">@ShortCategory(row.Category)</td>
+                                <td>
+                                    @row.Message
+                                    @if (row.Exception is not null)
+                                    {
+                                        <details><summary class="small text-danger">exception</summary><pre class="small mb-0">@row.Exception</pre></details>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+            <Pager Page="page" TotalCount="logs.TotalCount" PageSize="PageSize" OnChange="OnPageChangedAsync" />
+        }
+    }
+    else
+    {
+        @if (auditEvents is null)
+        {
+            <p>Loading...</p>
+        }
+        else if (auditEvents.Items.Count == 0)
+        {
+            <p class="text-muted">No audit events yet.</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-striped table-sm align-middle">
+                    <thead>
+                        <tr><th>Time</th><th>Actor</th><th>Action</th><th>Target</th><th>Detail</th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (AuditEventRow row in auditEvents.Items)
+                        {
+                            <tr>
+                                <td class="text-nowrap">@row.OccurredAtUtc.ToLocalTime().ToString("g")</td>
+                                <td>@(row.ActorName ?? "-")</td>
+                                <td><code>@row.Action</code></td>
+                                <td>@(row.Target ?? "-")</td>
+                                <td class="small text-muted">@(row.Detail ?? "-")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+            <Pager Page="page" TotalCount="auditEvents.TotalCount" PageSize="PageSize" OnChange="OnPageChangedAsync" />
+        }
+    }
+</div>
+
+@code {
+    private const int PageSize = 50;
+
+    private bool showAudit;
+    private int page = 1;
+    private string level = string.Empty;
+    private string search = string.Empty;
+    private bool loadFailed;
+
+    private PagedResult<LogEntryRow>? logs;
+    private PagedResult<AuditEventRow>? auditEvents;
+    private VerboseStatusResponse? verbose;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadVerboseAsync();
+        await ReloadAsync();
+    }
+
+    private async Task SwitchTabAsync(bool audit)
+    {
+        showAudit = audit;
+        page = 1;
+        await ReloadAsync();
+    }
+
+    private async Task ReloadAsync()
+    {
+        loadFailed = false;
+
+        try
+        {
+            if (showAudit)
+            {
+                auditEvents = await Http.GetFromJsonAsync<PagedResult<AuditEventRow>>(
+                    $"api/v1/admin/logs/audit?page={page}&pageSize={PageSize}");
+            }
+            else
+            {
+                logs = await Http.GetFromJsonAsync<PagedResult<LogEntryRow>>(
+                    $"api/v1/admin/logs?page={page}&pageSize={PageSize}&level={Uri.EscapeDataString(level)}&search={Uri.EscapeDataString(search)}");
+            }
+        }
+        catch (HttpRequestException)
+        {
+            loadFailed = true;
+        }
+    }
+
+    private async Task LoadVerboseAsync()
+    {
+        try
+        {
+            verbose = await Http.GetFromJsonAsync<VerboseStatusResponse>("api/v1/admin/logs/verbose");
+        }
+        catch (HttpRequestException)
+        {
+            loadFailed = true;
+        }
+    }
+
+    private async Task ToggleVerboseAsync(ChangeEventArgs e)
+    {
+        try
+        {
+            HttpResponseMessage response = await Http.PutAsJsonAsync(
+                "api/v1/admin/logs/verbose", new VerboseRequest { Enabled = e.Value is true });
+            if (response.IsSuccessStatusCode)
+            {
+                verbose = await response.Content.ReadFromJsonAsync<VerboseStatusResponse>();
+            }
+        }
+        catch (HttpRequestException)
+        {
+            loadFailed = true;
+        }
+    }
+
+    private async Task OnPageChangedAsync(int newPage)
+    {
+        page = newPage;
+        await ReloadAsync();
+    }
+
+    private async Task OnSearchKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            page = 1;
+            await ReloadAsync();
+        }
+    }
+
+    private static string ShortCategory(string category)
+    {
+        int lastDot = category.LastIndexOf('.');
+        return lastDot < 0 ? category : category[(lastDot + 1)..];
+    }
+
+    private static string LevelBadge(string level) => level switch
+    {
+        "Critical" or "Error" => "text-bg-danger",
+        "Warning" => "text-bg-warning",
+        "Information" => "text-bg-info",
+        _ => "text-bg-secondary"
+    };
+}

--- a/src/FairShare.Web/Pages/Admin/Stats.razor
+++ b/src/FairShare.Web/Pages/Admin/Stats.razor
@@ -1,0 +1,197 @@
+@page "/admin/stats"
+@using FairShare.Contracts.Observability
+@attribute [Authorize(Policy = "AdminOnly")]
+@inject HttpClient Http
+
+<PageTitle>FairShare - Stats</PageTitle>
+
+<div class="container my-4">
+    <div class="d-flex align-items-center gap-3 mb-3 flex-wrap">
+        <h2 class="mb-0">Stats</h2>
+        <select @bind="days" @bind:after="LoadAllAsync" class="form-select" style="width: auto;" aria-label="Period">
+            <option value="7">Last 7 days</option>
+            <option value="30">Last 30 days</option>
+            <option value="90">Last 90 days</option>
+            <option value="365">Last 365 days</option>
+            <option value="0">All time</option>
+        </select>
+        @if (summary?.FirstDay is DateOnly first && days == 0)
+        {
+            <span class="text-muted small">since @first.ToString("yyyy-MM-dd")</span>
+        }
+    </div>
+
+    @if (loadFailed)
+    {
+        <div class="alert alert-warning" role="alert">Could not load statistics. Try again shortly.</div>
+    }
+    else if (summary is null)
+    {
+        <p>Loading...</p>
+    }
+    else
+    {
+        <div class="row g-3 mb-4">
+            <StatTile Label="Page views" Value="@summary.PageViews" />
+            <StatTile Label="Daily visitors" Value="@summary.DailyVisitors" />
+            <StatTile Label="Calculations" Value="@summary.CalculationsCompleted" />
+            <StatTile Label="Gated hits" Value="@summary.GatedHits" />
+            <StatTile Label="Donate clicks" Value="@summary.DonateClicks" />
+        </div>
+
+        <div class="row g-4">
+            <div class="col-lg-7">
+                <h5>Top pages</h5>
+                @if (pages is null || pages.Items.Count == 0)
+                {
+                    <p class="text-muted">No page views in this period.</p>
+                }
+                else
+                {
+                    <div class="table-responsive">
+                        <table class="table table-striped table-sm align-middle">
+                            <thead>
+                                <tr>
+                                    <th role="button" @onclick='() => SortPages("path")'>Path @SortMarker("path")</th>
+                                    <th role="button" class="text-end" @onclick='() => SortPages("views")'>Views @SortMarker("views")</th>
+                                    <th role="button" class="text-end" @onclick='() => SortPages("visitors")'>Visitors @SortMarker("visitors")</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (PageStatRow row in pages.Items)
+                                {
+                                    <tr>
+                                        <td><code>@row.Path</code></td>
+                                        <td class="text-end">@row.Views</td>
+                                        <td class="text-end">@row.Visitors</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                    @if (pages.TotalCount > pages.PageSize)
+                    {
+                        <nav aria-label="Top pages pagination" class="d-flex gap-2 align-items-center">
+                            <button class="btn btn-sm btn-outline-secondary" disabled="@(page <= 1)" @onclick="() => ChangePageAsync(-1)">Previous</button>
+                            <span class="small text-muted">Page @(page) of @TotalPages</span>
+                            <button class="btn btn-sm btn-outline-secondary" disabled="@(page >= TotalPages)" @onclick="() => ChangePageAsync(1)">Next</button>
+                        </nav>
+                    }
+                }
+            </div>
+            <div class="col-lg-5">
+                <h5>Top referrers</h5>
+                @if (referrers is null || referrers.Count == 0)
+                {
+                    <p class="text-muted">No external referrers in this period.</p>
+                }
+                else
+                {
+                    <table class="table table-striped table-sm align-middle">
+                        <thead><tr><th>Referrer</th><th class="text-end">Views</th></tr></thead>
+                        <tbody>
+                            @foreach (ReferrerStatRow row in referrers)
+                            {
+                                <tr><td>@row.ReferrerHost</td><td class="text-end">@row.Views</td></tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+
+                <h5 class="mt-4">Events</h5>
+                @if (events is null || events.Count == 0)
+                {
+                    <p class="text-muted">No events in this period.</p>
+                }
+                else
+                {
+                    <table class="table table-striped table-sm align-middle">
+                        <thead><tr><th>Event</th><th class="text-end">Count</th></tr></thead>
+                        <tbody>
+                            @foreach (EventStatRow row in events)
+                            {
+                                <tr>
+                                    <td>@row.Name@(row.Target is null ? string.Empty : $" · {row.Target}")</td>
+                                    <td class="text-end">@row.Count</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    private int days = 30;
+    private int page = 1;
+    private const int PageSize = 10;
+    private string sort = "views";
+    private bool desc = true;
+    private bool loadFailed;
+
+    private StatsSummaryResponse? summary;
+    private PagedResult<PageStatRow>? pages;
+    private List<ReferrerStatRow>? referrers;
+    private List<EventStatRow>? events;
+
+    private int TotalPages => pages is null ? 1 : Math.Max(1, (pages.TotalCount + PageSize - 1) / PageSize);
+
+    protected override Task OnInitializedAsync() => LoadAllAsync();
+
+    private async Task LoadAllAsync()
+    {
+        page = 1;
+        loadFailed = false;
+
+        try
+        {
+            summary = await Http.GetFromJsonAsync<StatsSummaryResponse>($"api/v1/admin/stats/summary?days={days}");
+            referrers = await Http.GetFromJsonAsync<List<ReferrerStatRow>>($"api/v1/admin/stats/referrers?days={days}");
+            events = await Http.GetFromJsonAsync<List<EventStatRow>>($"api/v1/admin/stats/events?days={days}");
+            await LoadPagesAsync();
+        }
+        catch (HttpRequestException)
+        {
+            loadFailed = true;
+        }
+    }
+
+    private async Task LoadPagesAsync()
+    {
+        try
+        {
+            pages = await Http.GetFromJsonAsync<PagedResult<PageStatRow>>(
+                $"api/v1/admin/stats/pages?days={days}&page={page}&pageSize={PageSize}&sort={sort}&desc={desc}");
+        }
+        catch (HttpRequestException)
+        {
+            loadFailed = true;
+        }
+    }
+
+    private async Task SortPages(string column)
+    {
+        if (sort == column)
+        {
+            desc = !desc;
+        }
+        else
+        {
+            sort = column;
+            desc = column != "path";
+        }
+
+        page = 1;
+        await LoadPagesAsync();
+    }
+
+    private async Task ChangePageAsync(int delta)
+    {
+        page = Math.Clamp(page + delta, 1, TotalPages);
+        await LoadPagesAsync();
+    }
+
+    private string SortMarker(string column) => sort != column ? string.Empty : desc ? "▼" : "▲";
+}

--- a/src/FairShare.Web/Pages/Admin/Stats.razor
+++ b/src/FairShare.Web/Pages/Admin/Stats.razor
@@ -52,9 +52,9 @@
                         <table class="table table-striped table-sm align-middle">
                             <thead>
                                 <tr>
-                                    <th role="button" @onclick='() => SortPages("path")'>Path @SortMarker("path")</th>
-                                    <th role="button" class="text-end" @onclick='() => SortPages("views")'>Views @SortMarker("views")</th>
-                                    <th role="button" class="text-end" @onclick='() => SortPages("visitors")'>Visitors @SortMarker("visitors")</th>
+                                    <th><button type="button" class="btn btn-link p-0 fw-bold text-decoration-none" @onclick='() => SortPages("path")'>Path @SortMarker("path")</button></th>
+                                    <th class="text-end"><button type="button" class="btn btn-link p-0 fw-bold text-decoration-none" @onclick='() => SortPages("views")'>Views @SortMarker("views")</button></th>
+                                    <th class="text-end"><button type="button" class="btn btn-link p-0 fw-bold text-decoration-none" @onclick='() => SortPages("visitors")'>Visitors @SortMarker("visitors")</button></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -152,8 +152,10 @@
             events = await Http.GetFromJsonAsync<List<EventStatRow>>($"api/v1/admin/stats/events?days={days}");
             await LoadPagesAsync();
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
+            // Also JsonException/NotSupportedException: an expired session can answer with
+            // non-JSON, and the page must degrade to the banner rather than crash.
             loadFailed = true;
         }
     }
@@ -165,7 +167,7 @@
             pages = await Http.GetFromJsonAsync<PagedResult<PageStatRow>>(
                 $"api/v1/admin/stats/pages?days={days}&page={page}&pageSize={PageSize}&sort={sort}&desc={desc}");
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
             loadFailed = true;
         }

--- a/src/FairShare.Web/Program.cs
+++ b/src/FairShare.Web/Program.cs
@@ -54,7 +54,8 @@ if (!await authApi.TryRefreshAsync())
 }
 
 // After auth bootstrap so the beacon's requests carry the session's own token (which is
-// how the server excludes the admin's browsing). Fire-and-forget by design.
-await host.Services.GetRequiredService<AnalyticsBeacon>().StartAsync();
+// how the server excludes the admin's browsing). Deliberately not awaited: analytics
+// must never delay first render.
+_ = host.Services.GetRequiredService<AnalyticsBeacon>().StartAsync();
 
 await host.RunAsync();

--- a/src/FairShare.Web/Program.cs
+++ b/src/FairShare.Web/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using FairShare.Web;
 using FairShare.Web.Auth;
+using FairShare.Web.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -36,6 +37,7 @@ builder.Services.AddHttpClient("Api", client => client.BaseAddress = new Uri(api
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("Api"));
 builder.Services.AddScoped<AuthApiClient>();
+builder.Services.AddSingleton<AnalyticsBeacon>();
 
 WebAssemblyHost host = builder.Build();
 
@@ -50,5 +52,9 @@ if (!await authApi.TryRefreshAsync())
 {
     await authApi.TryStartGuestSessionAsync();
 }
+
+// After auth bootstrap so the beacon's requests carry the session's own token (which is
+// how the server excludes the admin's browsing). Fire-and-forget by design.
+await host.Services.GetRequiredService<AnalyticsBeacon>().StartAsync();
 
 await host.RunAsync();

--- a/src/FairShare.Web/Services/AnalyticsBeacon.cs
+++ b/src/FairShare.Web/Services/AnalyticsBeacon.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FairShare.Contracts.Observability;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.JSInterop;
+
+namespace FairShare.Web.Services;
+
+/// <summary>
+/// First-party page-view beacon (ADR 0003). nginx serves this SPA, so route changes never
+/// reach the API on their own; this posts them. Honors DNT/Global Privacy Control before
+/// sending anything (the server checks again), sets no cookies or identifiers, and is
+/// strictly fire-and-forget - analytics must never affect the visitor's experience.
+/// </summary>
+public sealed class AnalyticsBeacon(NavigationManager navigation, IHttpClientFactory httpClientFactory, IJSRuntime js) : IDisposable
+{
+    private readonly NavigationManager _navigation = navigation;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+    private readonly IJSRuntime _js = js;
+
+    private bool _started;
+    private bool _optedOut;
+
+    public async Task StartAsync()
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+
+        try
+        {
+            _optedOut = await _js.InvokeAsync<bool>("fairshareAnalytics.isOptedOut");
+        }
+        catch
+        {
+            // If the helper is unavailable (stale cached assets), err on the quiet side.
+            _optedOut = true;
+        }
+
+        if (_optedOut)
+        {
+            return;
+        }
+
+        // Initial load carries the external referrer; SPA route changes have none.
+        string? referrer = null;
+        try
+        {
+            referrer = await _js.InvokeAsync<string?>("fairshareAnalytics.referrer");
+        }
+        catch
+        {
+            // Optional enrichment only.
+        }
+
+        await TrackPageAsync(_navigation.Uri, referrer);
+        _navigation.LocationChanged += OnLocationChanged;
+    }
+
+    /// <summary>Reports a guest running into a users-only feature (conversion-intent signal).</summary>
+    public async Task TrackGatedHitAsync(string gate)
+    {
+        if (!_started || _optedOut)
+        {
+            return;
+        }
+
+        await PostQuietlyAsync("api/v1/analytics/events", new ClientEventRequest { Name = "gated-hit", Target = gate });
+    }
+
+    private async void OnLocationChanged(object? sender, LocationChangedEventArgs e) =>
+        await TrackPageAsync(e.Location, referrer: null);
+
+    private async Task TrackPageAsync(string uri, string? referrer)
+    {
+        string path = "/" + _navigation.ToBaseRelativePath(uri);
+        await PostQuietlyAsync("api/v1/analytics/page-views", new PageViewRequest { Path = path, Referrer = referrer });
+    }
+
+    private async Task PostQuietlyAsync<T>(string route, T payload)
+    {
+        try
+        {
+            HttpClient client = _httpClientFactory.CreateClient("Api");
+            await client.PostAsJsonAsync(route, payload);
+        }
+        catch
+        {
+            // Ad-blockers and offline states are expected; the page must never notice.
+        }
+    }
+
+    public void Dispose() => _navigation.LocationChanged -= OnLocationChanged;
+}

--- a/src/FairShare.Web/Services/AnalyticsBeacon.cs
+++ b/src/FairShare.Web/Services/AnalyticsBeacon.cs
@@ -74,8 +74,10 @@ public sealed class AnalyticsBeacon(NavigationManager navigation, IHttpClientFac
         await PostQuietlyAsync("api/v1/analytics/events", new ClientEventRequest { Name = "gated-hit", Target = gate });
     }
 
-    private async void OnLocationChanged(object? sender, LocationChangedEventArgs e) =>
-        await TrackPageAsync(e.Location, referrer: null);
+    // Synchronous handler kicking off a task (not async void): TrackPageAsync swallows its
+    // own failures, so the discarded task can never surface an unobserved exception.
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e) =>
+        _ = TrackPageAsync(e.Location, referrer: null);
 
     private async Task TrackPageAsync(string uri, string? referrer)
     {

--- a/src/FairShare.Web/wwwroot/js/site.js
+++ b/src/FairShare.Web/wwwroot/js/site.js
@@ -13,6 +13,19 @@ window.fairshareDownload = {
     }
 };
 
+// First-party analytics helpers: browser privacy signals and the first-load referrer.
+// No cookies, no identifiers, nothing stored client-side (ADR 0003).
+window.fairshareAnalytics = {
+    isOptedOut: function () {
+        return navigator.doNotTrack === '1'
+            || window.doNotTrack === '1'
+            || navigator.globalPrivacyControl === true;
+    },
+    referrer: function () {
+        return document.referrer || null;
+    }
+};
+
 window.fairshareTheme = {
     THEME_KEY: 'fairshare-theme',
     apply: function (theme) {


### PR DESCRIPTION
Closes #100. Effort 1 of 3 (observability → public sign-in → donations); design settled in a grilling session and recorded in ADR 0003 (this PR also lands ADR 0004, the accounts design for effort 2, plus the new CONTEXT.md observability vocabulary).

## What's here

**First-party cookieless analytics** (ADR 0003)
- SPA page-view beacon (`POST api/v1/analytics/page-views`) — nginx serves the WASM app, so route changes never reach the API on their own
- Content-free events: `calculation-started`/`calculation-completed` (server-recorded, target = form key only), `gated-hit` (the one client-postable name — whitelist prevents forging server events)
- Daily visitors via `HMAC(secret, UTC-date + IP + UA)` — the date in the payload makes cross-day linkage impossible; IP/UA are never stored
- DNT and Sec-GPC mean *nothing is recorded* (checked client and server side); bot UAs (empty UA = bot) and the admin's own browsing excluded
- Nightly 00:20 UTC rollup (startup catch-up, idempotent delete-then-insert per day, zero-traffic days still advance the watermark); raw rows purged after 90 days, aggregates permanent, "today" computed live

**Persistent logs + audit trail**
- Hand-rolled `ILoggerProvider` → bounded channel → raw-ADO batch sink into SQLite (**zero new package deps**; raw ADO so the sink can never recurse through EF's own logging)
- Verbose mode: admin toggle raises capture to Debug and **always turns itself back off** (~4 h or restart); each toggle is an audit event
- Retention: diagnostics 30 days, audit events ~1 year (rows outlive deleted accounts by design)
- Previously-unaudited surfaces now audited: login success/failure, user create/update/delete, password reset/change

**Admin UI**: `/admin/stats` (period selector, tiles: views · daily visitors · calculations · gated hits · donate clicks; sortable top pages; referrers; events) and `/admin/logs` (level filter, search, paging, audit tab, verbose switch). A guest landing on a users-only page now gets a sign-in invitation (counted as `gated-hit`) instead of a dead-end "Access denied".

**Ops rider**: `json-file` log rotation (10m × 3) in the compose files — container stdout grew unbounded before.

## Privacy hard wall (NFR-1)

No financial values, parent names, or case content can enter any log, stat, or audit row: event targets are restricted to kebab-case tokens, request payloads are never logged, message/exception lengths are capped, and EF Core categories below Warning are never captured (also the recursion guard).

## Tests

24 new (rules, visitor key, level switch auto-revert, pure rollup, integration: bot/DNT/admin exclusion, forged-event rejection, admin-only enforcement, verbose audit, maintenance rollup+purge idempotency) — **224/224 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)