### PR TITLE
feat: donations — Support page, footer link, first-party donate redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ ADMIN_SEED_LOG_GENERATED_PASSWORD=true
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
+# Donations (optional): the https URL of your Buy Me a Coffee (or similar) page.
+# Leave blank to hide the donate button; the Support page still explains the project.
+DONATE_URL=
+
 # Host ports (browser-visible).
 WEB_PORT=5858
 API_PORT=5859

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       # Google sign-in (ADR 0004): leave unset to run without public sign-up.
       Authentication__Google__ClientId: "${GOOGLE_CLIENT_ID:-}"
       Authentication__Google__ClientSecret: "${GOOGLE_CLIENT_SECRET:-}"
+      # Donations: https URL of the operator's Buy Me a Coffee page; unset hides the Support surface.
+      Donations__BuyMeACoffeeUrl: "${DONATE_URL:-}"
       Cors__AllowedOrigins__0: "${WEB_ORIGIN:-http://localhost:5858}"
       # DataProtection keys on the data volume so Identity tokens survive container recreates.
       DataProtection__KeysPath: "/data/keys"

--- a/docs/API.md
+++ b/docs/API.md
@@ -229,6 +229,7 @@ Diagnostic logs persist 30 days; audit events ~1 year (and survive account delet
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
+| GET | `/go/donate` | none | First-party donate redirect: 302 to the operator's configured Buy Me a Coffee page (`Donations:BuyMeACoffeeUrl`, https only), counting an anonymous `donate-click` event first (same opt-out/bot/admin rules as all analytics). **404** when unconfigured. `GET /auth/config` exposes `donationsEnabled`. |
 | GET | `/healthz` | none | Liveness probe: `{ "status": "ok" }`. Exempt from rate limiting. |
 
 ---

--- a/src/FairShare.Api/Controllers/AuthController.cs
+++ b/src/FairShare.Api/Controllers/AuthController.cs
@@ -50,7 +50,12 @@ public class AuthController(
     [HttpGet("config")]
     [AllowAnonymous]
     public ActionResult<AuthConfigResponse> GetConfig() =>
-        Ok(new AuthConfigResponse { GoogleEnabled = GoogleEnabled });
+        Ok(new AuthConfigResponse
+        {
+            GoogleEnabled = GoogleEnabled,
+            DonationsEnabled = Uri.TryCreate(_configuration["Donations:BuyMeACoffeeUrl"], UriKind.Absolute, out Uri? donateUri)
+                && donateUri.Scheme == Uri.UriSchemeHttps
+        });
 
     [HttpPost("login")]
     [AllowAnonymous]

--- a/src/FairShare.Api/Controllers/SupportController.cs
+++ b/src/FairShare.Api/Controllers/SupportController.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Observability;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+
+namespace FairShare.Api.Controllers;
+
+/// <summary>
+/// First-party donate redirect (Portfolio's /go pattern): the SPA links here so the click
+/// can be counted as an anonymous donate-click event before the 302 to the configured,
+/// admin-controlled destination - no open redirect, payment happens entirely off-site.
+/// Unconfigured instances 404 and the SPA hides the Support surface.
+/// </summary>
+[Route("go")]
+[AllowAnonymous]
+public class SupportController(IAnalyticsService analytics, IConfiguration configuration) : ControllerBase
+{
+    private readonly IAnalyticsService _analytics = analytics;
+    private readonly IConfiguration _configuration = configuration;
+
+    [HttpGet("donate")]
+    public async Task<IActionResult> Donate(CancellationToken ct)
+    {
+        string? destination = _configuration["Donations:BuyMeACoffeeUrl"];
+
+        if (string.IsNullOrWhiteSpace(destination)
+            || !Uri.TryCreate(destination, UriKind.Absolute, out Uri? uri)
+            || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            return NotFound();
+        }
+
+        // Best-effort and rule-filtered (bots, DNT/GPC, the admin) like every event;
+        // the redirect happens regardless of whether anything was recorded.
+        await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.DonateClick, target: null, ct);
+
+        return Redirect(uri.ToString());
+    }
+}

--- a/src/FairShare.Contracts/Auth/AuthContracts.cs
+++ b/src/FairShare.Contracts/Auth/AuthContracts.cs
@@ -34,6 +34,9 @@ public class AuthConfigResponse
 {
     /// <summary>Whether "Sign in with Google" is configured on this server.</summary>
     public bool GoogleEnabled { get; set; }
+
+    /// <summary>Whether a donation destination is configured (shows the Support surface).</summary>
+    public bool DonationsEnabled { get; set; }
 }
 
 /// <summary>401 body when a password checked out but the account requires a TOTP code.

--- a/src/FairShare.Tests/Api/SupportEndpointTests.cs
+++ b/src/FairShare.Tests/Api/SupportEndpointTests.cs
@@ -1,0 +1,109 @@
+using FairShare.Api.Persistence;
+using FairShare.Contracts.Auth;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class SupportEndpointTests : IClassFixture<FairShareApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public SupportEndpointTests(FairShareApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+
+    [Fact]
+    public async Task Donate_WithoutConfiguredUrl_Returns404()
+    {
+        HttpResponseMessage response = await _client.GetAsync("go/donate");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Config_WithoutConfiguredUrl_ReportsDonationsDisabled()
+    {
+        AuthConfigResponse config = (await _client.GetFromJsonAsync<AuthConfigResponse>("api/v1/auth/config"))!;
+
+        Assert.False(config.DonationsEnabled);
+    }
+}
+
+public class DonationsEnabledApiFactory : FairShareApiFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        SetEnvVar("Donations__BuyMeACoffeeUrl", "https://buymeacoffee.com/example");
+    }
+}
+
+[Collection("Api")]
+public class SupportEnabledEndpointTests : IClassFixture<DonationsEnabledApiFactory>
+{
+    private const string BrowserUa =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+    private readonly DonationsEnabledApiFactory _factory;
+    private readonly HttpClient _client;
+
+    public SupportEnabledEndpointTests(DonationsEnabledApiFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost"),
+            AllowAutoRedirect = false
+        });
+        _client.DefaultRequestHeaders.UserAgent.ParseAdd(BrowserUa);
+    }
+
+    [Fact]
+    public async Task Config_ReportsDonationsEnabled()
+    {
+        AuthConfigResponse config = (await _client.GetFromJsonAsync<AuthConfigResponse>("api/v1/auth/config"))!;
+
+        Assert.True(config.DonationsEnabled);
+    }
+
+    [Fact]
+    public async Task Donate_RedirectsToConfiguredUrl_AndCountsTheClick()
+    {
+        HttpResponseMessage response = await _client.GetAsync("go/donate");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Equal("https://buymeacoffee.com/example", response.Headers.Location!.ToString().TrimEnd('/'));
+
+        using IServiceScope scope = _factory.Services.CreateScope();
+        FairShareDbContext db = scope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+        Assert.Equal(1, db.AnalyticsEvents.Count(e => e.Name == "donate-click"));
+    }
+
+    [Fact]
+    public async Task Donate_WithDoNotTrack_StillRedirects_ButRecordsNothing()
+    {
+        int before;
+        using (IServiceScope scope = _factory.Services.CreateScope())
+        {
+            before = scope.ServiceProvider.GetRequiredService<FairShareDbContext>()
+                .AnalyticsEvents.Count(e => e.Name == "donate-click");
+        }
+
+        HttpRequestMessage request = new(HttpMethod.Get, "go/donate");
+        request.Headers.Add("DNT", "1");
+
+        HttpResponseMessage response = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+
+        using IServiceScope verifyScope = _factory.Services.CreateScope();
+        FairShareDbContext db = verifyScope.ServiceProvider.GetRequiredService<FairShareDbContext>();
+        Assert.Equal(before, db.AnalyticsEvents.Count(e => e.Name == "donate-click"));
+    }
+}

--- a/src/FairShare.Web/Layout/MainLayout.razor
+++ b/src/FairShare.Web/Layout/MainLayout.razor
@@ -10,6 +10,7 @@
 <footer class="container small text-muted py-4 d-flex gap-3 flex-wrap">
     <span>&copy; @DateTime.UtcNow.Year - FairShare v@(AppVersion)</span>
     <a href="/privacy" class="link-secondary">Privacy</a>
+    <a href="/support" class="link-secondary">Support FairShare</a>
 </footer>
 
 @code {

--- a/src/FairShare.Web/Pages/Support.razor
+++ b/src/FairShare.Web/Pages/Support.razor
@@ -1,0 +1,63 @@
+@page "/support"
+@attribute [AllowAnonymous]
+@inject FairShare.Web.Auth.AuthApiClient AuthApi
+@inject HttpClient Http
+
+<PageTitle>FairShare - Support</PageTitle>
+
+<div class="container my-5" style="max-width: 640px;">
+    <h1 class="h3 mb-4">Support FairShare</h1>
+
+    <p class="lead">
+        FairShare is free, has no ads, and sells nothing - least of all your data.
+        It stays that way because it costs one person a manageable amount to run.
+    </p>
+
+    <p>
+        What it actually takes: a server that is on around the clock, the domain, backups,
+        and the hours that go into keeping the worksheets matched to Alabama's official
+        forms as they change. None of that requires your money - the calculator is yours
+        either way, and no feature ever sits behind a donation.
+    </p>
+
+    <p>
+        But if the tool helped you through a hard season and you would like to chip in,
+        a few dollars genuinely covers real costs and keeps it free for the next parent:
+    </p>
+
+    @if (_donationsEnabled)
+    {
+        <p class="my-4">
+            <a class="btn btn-warning" href="@DonateHref" rel="noopener">
+                ☕ Buy me a coffee
+            </a>
+        </p>
+        <p class="text-muted small">
+            Donations happen entirely on Buy Me a Coffee's site - FairShare never sees or
+            stores any payment details. The click itself is counted only as an anonymous
+            "someone donated-clicked today" (see the <a href="/privacy">privacy page</a>).
+        </p>
+    }
+    else
+    {
+        <p class="text-muted">Donations aren't set up on this server - just enjoy the tool.</p>
+    }
+
+    <div class="mt-4">
+        <a href="/" class="btn btn-link">&larr; Back to the calculator</a>
+    </div>
+</div>
+
+@code {
+    private bool _donationsEnabled;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var config = await AuthApi.GetAuthConfigAsync();
+        _donationsEnabled = config.DonationsEnabled;
+    }
+
+    // Top-level navigation to the API's first-party redirect (not an XHR), so the click
+    // is counted server-side and the destination stays admin-controlled.
+    private string DonateHref => $"{Http.BaseAddress}go/donate";
+}


### PR DESCRIPTION
Closes #106. Effort 3 of 3 — the settled design (grilling Q13/Q14): keep the existing Buy Me a Coffee account, footer link + dedicated Support page, and **never** an ask inside the calculation flow.

## What's here

- **`GET /go/donate`** — first-party redirect (Portfolio's `/go` pattern): 302 to the operator-configured `Donations:BuyMeACoffeeUrl` (https-only; 404 when unset — no open redirect), counting an anonymous `donate-click` event first under the same DNT/GPC, bot, and admin-exclusion rules as every other event. The redirect happens whether or not anything was recorded.
- **`/support` page** — earnest, pressure-free copy about what the free site costs to run; the donate button renders only when configured (`GET /auth/config` now includes `donationsEnabled`); explicit disclosure that payment happens entirely off-site.
- **Footer** gains "Support FairShare" next to Privacy.
- `DONATE_URL` env passthrough in compose + `.env.example`.

## Tests

**236/236 green**; new: 404 when unconfigured, config flag both ways, 302 + click counted, and DNT still-redirects-but-records-nothing.

With this merged, the pending release PR carries the whole v4.0.0 line (public sign-in + donations) for a single deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)