### PR TITLE
fix: rename admin stats events endpoint to dodge ad-blocker filter lists

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -210,7 +210,7 @@ First-party, cookieless capture endpoints for the SPA (see `docs/adr/0003-first-
 | GET | `/admin/stats/summary?days=30` | Tiles: `{ pageViews, dailyVisitors, calculationsCompleted, gatedHits, donateClicks, firstDay }`. |
 | GET | `/admin/stats/pages?days=&page=&pageSize=&sort=views\|visitors\|path&desc=` | Top pages, paged: `{ items: [{ path, views, visitors }], page, pageSize, totalCount }`. |
 | GET | `/admin/stats/referrers?days=` | Top 10 external referrer hosts: `[{ referrerHost, views }]`. |
-| GET | `/admin/stats/events?days=` | Event counts: `[{ name, target, count }]`, descending. |
+| GET | `/admin/stats/activity?days=` | Event counts: `[{ name, target, count }]`, descending. (Named "activity" rather than "events" because ad-blocker filter lists block `/stats/events` URL patterns, which broke the page for admins running a blocker.) |
 
 ## Admin logs — `/api/v1/admin/logs` (Bearer + Admin role)
 

--- a/src/FairShare.Api/Controllers/StatsController.cs
+++ b/src/FairShare.Api/Controllers/StatsController.cs
@@ -33,7 +33,11 @@ public class StatsController(IAnalyticsService analytics) : ControllerBase
     public async Task<ActionResult<List<ReferrerStatRow>>> GetReferrers(int? days, CancellationToken ct) =>
         Ok(await _analytics.GetTopReferrersAsync(Normalize(days), take: 10, ct));
 
-    [HttpGet("events")]
+    // "activity", not "events": ad-blocker filter lists (EasyPrivacy etc.) block URL
+    // patterns like "/stats/events" on any site, which broke this page for admins running
+    // a blocker - the beacon endpoints stay blockable by design (ADR 0003), but the
+    // admin's own dashboard reading its own data is not tracking anyone.
+    [HttpGet("activity")]
     public async Task<ActionResult<List<EventStatRow>>> GetEvents(int? days, CancellationToken ct) =>
         Ok(await _analytics.GetEventsAsync(Normalize(days), ct));
 

--- a/src/FairShare.Tests/Api/ObservabilityEndpointsTests.cs
+++ b/src/FairShare.Tests/Api/ObservabilityEndpointsTests.cs
@@ -153,7 +153,7 @@ public class ObservabilityEndpointsTests : IClassFixture<FairShareApiFactory>
         foreach (string route in new[]
                  {
                      "api/v1/admin/stats/summary", "api/v1/admin/stats/pages", "api/v1/admin/stats/referrers",
-                     "api/v1/admin/stats/events", "api/v1/admin/logs", "api/v1/admin/logs/audit", "api/v1/admin/logs/verbose"
+                     "api/v1/admin/stats/activity", "api/v1/admin/logs", "api/v1/admin/logs/audit", "api/v1/admin/logs/verbose"
                  })
         {
             Assert.Equal(HttpStatusCode.Unauthorized, (await _client.GetAsync(route)).StatusCode);

--- a/src/FairShare.Web/Pages/Admin/Stats.razor
+++ b/src/FairShare.Web/Pages/Admin/Stats.razor
@@ -149,7 +149,8 @@
         {
             summary = await Http.GetFromJsonAsync<StatsSummaryResponse>($"api/v1/admin/stats/summary?days={days}");
             referrers = await Http.GetFromJsonAsync<List<ReferrerStatRow>>($"api/v1/admin/stats/referrers?days={days}");
-            events = await Http.GetFromJsonAsync<List<EventStatRow>>($"api/v1/admin/stats/events?days={days}");
+            // "activity" route: the natural name ("events") trips ad-blocker filter lists.
+            events = await Http.GetFromJsonAsync<List<EventStatRow>>($"api/v1/admin/stats/activity?days={days}");
             await LoadPagesAsync();
         }
         catch (Exception)


### PR DESCRIPTION
Found in prod minutes after the v4.0.0 deploy: `/admin/stats` showed "Could not load statistics" on the desktop but worked on a phone. NPM logs showed every desktop attempt fetching `summary` and `referrers` successfully, then never sending the `events` request — the desktop's content blocker kills any URL matching EasyPrivacy-style `/stats/events` patterns before it leaves the browser.

**Fix**: `GET /api/v1/admin/stats/events` → `GET /api/v1/admin/stats/activity` (API + SPA + tests + docs). The response shape is unchanged.

**Deliberately not changed**: the public beacon endpoints (`/api/v1/analytics/*`) keep their honest names — a visitor's ad blocker is an opt-out signal we respect (ADR 0003 accepts the undercount). The admin's own dashboard reading its own aggregates is a different case: it tracks no one, so evading the filter list there is a UX fix, not circumvention.

Tests: 236/236 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)