### PR TITLE
feat: legal surface - /terms page, results disclaimer, sign-in agreement line, license repair

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,6 +33,7 @@ The ubiquitous language of the FairShare domain: child-support worksheets as the
 | **Shared 50% physical-custody obligation** | CS-42-S line 5: 150% of the BCSO, reflecting two households. |
 | **Shared-custody credit** | CS-42-S line 12: half of the shared obligation credited to each parent for the time the children are with them. |
 | **Recommended child-support order** | The last line of either form: the amount the paying parent owes per month. On CS-42 the order applies to the non-custodial parent; on CS-42-S it is the higher line-13 amount, placed in that parent's column. |
+| **Estimate** | What FairShare produces: a calculation of the recommended order under a state's published guidelines. Never a court order — only a court sets an actual support obligation. |
 | **Payer** | The parent the recommended order applies to. "No net transfer" means neither parent owes the other. |
 | **Custodial parent** | On CS-42, the parent with primary physical custody; the other parent is the payer. CS-42-S has no custodial parent. |
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,202 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) {2025} {Joshua Mykitta}
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   1. Definitions.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,8 @@
 FairShare
 
-Copyright (c) {2025} {Joshua Mykitta}
+Copyright (c) 2025-2026 Joshua Mykitta
 
-This product includes software developed by {Joshua Mykitta} (https://github.com/JJWren).
+This product includes software developed by Joshua Mykitta (https://github.com/JJWren).
 
 Third-party components:
 - ClosedXML (MIT License) - https://github.com/ClosedXML/ClosedXML - used by the API to fill worksheet workbooks.

--- a/src/FairShare.Web/Layout/MainLayout.razor
+++ b/src/FairShare.Web/Layout/MainLayout.razor
@@ -9,8 +9,11 @@
 
 <footer class="container small text-muted py-4 d-flex gap-3 flex-wrap">
     <span>&copy; @DateTime.UtcNow.Year - FairShare v@(AppVersion)</span>
+    <a href="/terms" class="link-secondary">Terms</a>
     <a href="/privacy" class="link-secondary">Privacy</a>
     <a href="/support" class="link-secondary">Support FairShare</a>
+    <a href="https://github.com/JJWren/FairShare/blob/HEAD/LICENSE" class="link-secondary"
+       rel="noopener" target="_blank" title="FairShare is open source">Apache-2.0</a>
 </footer>
 
 @code {

--- a/src/FairShare.Web/Pages/Calculator.razor
+++ b/src/FairShare.Web/Pages/Calculator.razor
@@ -197,6 +197,11 @@
                 }
             </div>
         </div>
+        <p class="text-muted small text-center mt-2 mb-0">
+            FairShare provides estimates for informational purposes only - not legal advice.
+            Actual support obligations are determined by the court under your state's
+            guidelines. See the <a href="/terms">terms</a>.
+        </p>
     </div>
 
     <div class="mt-4">

--- a/src/FairShare.Web/Pages/Home.razor
+++ b/src/FairShare.Web/Pages/Home.razor
@@ -7,7 +7,15 @@
 <PageTitle>FairShare - Select State</PageTitle>
 
 <div class="container my-5">
-    <h1 class="h4 mb-4 text-center">Choose Your State</h1>
+    @* The home page must name the app and state its purpose in a first-time visitor's
+       words - Google's OAuth verification checks that the consent screen's app name
+       matches what this page shows and that the purpose is stated here. *@
+    <h1 class="h3 mb-2 text-center">FairShare</h1>
+    <p class="lead text-center mx-auto mb-4" style="max-width: 640px;">
+        A free child-support calculator: transparent, line-by-line estimates under your
+        state's official guidelines, matching the court's own worksheets.
+    </p>
+    <h2 class="h5 mb-4 text-center">Choose your state</h2>
 
     @if (states is null)
     {

--- a/src/FairShare.Web/Pages/Login.razor
+++ b/src/FairShare.Web/Pages/Login.razor
@@ -28,6 +28,11 @@
             Sign in with Google
         </a>
 
+        <p class="text-muted small text-center mt-2 mb-0">
+            By continuing, you agree to the <a href="/terms">terms</a> and
+            <a href="/privacy">privacy policy</a>.
+        </p>
+
         <div class="form-check mt-3">
             <input class="form-check-input" type="checkbox" id="rememberDevice" @bind="_rememberDevice" />
             <label class="form-check-label" for="rememberDevice">

--- a/src/FairShare.Web/Pages/Terms.razor
+++ b/src/FairShare.Web/Pages/Terms.razor
@@ -5,8 +5,10 @@
 
 @* Every sentence on this page must stay literally true of the running code and how the
    project is operated (same contract as Privacy.razor). If a change would falsify one,
-   change the sentence in the same PR. Keep all legal copy state-agnostic - "your state's
-   guidelines", never a named state - so adding states never requires touching this page. *@
+   change the sentence in the same PR. Keep the calculator-facing legal copy state-agnostic
+   - "your state's guidelines", never a named state - so adding states never requires
+   touching this page. The Governing-law section is the deliberate exception: it names the
+   operator's home state, which is independent of the states the calculator supports. *@
 <div class="container my-5" style="max-width: 720px;">
     <h1 class="h3 mb-1">Terms of Use</h1>
     <p class="text-muted small">Last updated: August 21, 2026</p>

--- a/src/FairShare.Web/Pages/Terms.razor
+++ b/src/FairShare.Web/Pages/Terms.razor
@@ -1,0 +1,91 @@
+@page "/terms"
+@attribute [AllowAnonymous]
+
+<PageTitle>FairShare - Terms</PageTitle>
+
+@* Every sentence on this page must stay literally true of the running code and how the
+   project is operated (same contract as Privacy.razor). If a change would falsify one,
+   change the sentence in the same PR. Keep all legal copy state-agnostic - "your state's
+   guidelines", never a named state - so adding states never requires touching this page. *@
+<div class="container my-5" style="max-width: 720px;">
+    <h1 class="h3 mb-1">Terms of Use</h1>
+    <p class="text-muted small">Last updated: August 21, 2026</p>
+    <p class="lead">
+        Plain language, no gotchas. This page describes the terms for using FairShare.
+    </p>
+
+    <h2 class="h5 mt-4">Accepting these terms</h2>
+    <p>
+        By using FairShare - browsing, calculating, or signing in - you agree to these terms.
+        If you do not agree, the remedy is simple: do not use the site.
+    </p>
+
+    <h2 class="h5 mt-4">Estimates, not legal advice</h2>
+    <p>
+        FairShare produces <strong>estimates</strong>, for informational and educational
+        purposes only. It is not legal advice, and it is not a substitute for an attorney
+        or for the court-approved worksheets. Actual support obligations are determined by
+        a court under your state's guidelines.
+    </p>
+    <p>
+        FairShare mirrors the published guidelines and official worksheets of the states it
+        supports, but states revise their forms and schedules, and the app may lag behind an
+        official revision. Confirm the current forms with the court or an attorney before
+        relying on a number.
+    </p>
+
+    <h2 class="h5 mt-4">Your account</h2>
+    <p>
+        Accounts are free, and sign-in uses your Google account - FairShare never holds a
+        password for you, so keeping your Google account secure is your responsibility.
+        You can stop using FairShare at any time and delete your account, and everything
+        it owns, yourself from the <a href="/account">account page</a>.
+    </p>
+
+    <h2 class="h5 mt-4">Your data</h2>
+    <p>
+        Everything FairShare stores - and everything it refuses to store - is described on
+        the <a href="/privacy">privacy page</a>. That page is the single source of truth
+        for data matters, and these terms defer to it.
+    </p>
+
+    <h2 class="h5 mt-4">Donations</h2>
+    <p>
+        Donations are voluntary and buy nothing: no feature sits behind them, no goods or
+        services are provided in return, and they are neither refundable nor tax-deductible.
+        Payment happens entirely on Buy Me a Coffee's site; FairShare never sees or stores
+        payment details.
+    </p>
+
+    <h2 class="h5 mt-4">No warranty</h2>
+    <p>
+        FairShare is a personal project provided <strong>"as is"</strong>, without warranties
+        of any kind. It may go down, change, or be discontinued at any time. To the maximum
+        extent permitted by law, its operator is not liable for any damages arising from its
+        use - including decisions made in reliance on its estimates.
+    </p>
+
+    <h2 class="h5 mt-4">Changes</h2>
+    <p>
+        These terms may change as FairShare evolves. The version published on this page is
+        always the current one, and the date at the top tells you when it last changed.
+    </p>
+
+    <h2 class="h5 mt-4">Governing law</h2>
+    <p>
+        These terms are governed by the laws of the State of Alabama, without regard to its
+        conflict-of-laws principles. That covers only the agreement between you and
+        FairShare's operator - your child-support matter is always governed by your own
+        state's law.
+    </p>
+
+    <h2 class="h5 mt-4">Contact</h2>
+    <p>
+        Questions about these terms:
+        <a href="mailto:joshua.j.wren@gmail.com">joshua.j.wren@gmail.com</a>.
+    </p>
+
+    <p class="text-muted small mt-4">
+        This page is written in good faith by Joshua Mykitta and is not legal advice.
+    </p>
+</div>


### PR DESCRIPTION
Closes #110

## What
- **`/terms` page** modeled on `Privacy.razor`'s shell, with the same "every sentence stays literally true" maintenance contract. Sections: accepting terms, **estimates-not-legal-advice** (including that the app may lag official form revisions), your account, your data (defers wholly to `/privacy` — nothing restated), donations (voluntary, nothing in return, non-refundable, not tax-deductible), no warranty, changes + "Last updated" date, governing law (Alabama — governs the agreement only, never the user's child-support matter), contact.
- **Results disclaimer**: an always-visible muted line beneath the calculator results card. Before this PR the "not legal advice" disclaimer existed only in the README — invisible to anyone actually using the calculator.
- **Sign-in agreement line** under the Google button: "By continuing, you agree to the terms and privacy policy."
- **Footer**: `Terms` and `Apache-2.0` (GitHub LICENSE blob, new tab) links added.
- **License repair**: `LICENSE` was the 19-line short-form boilerplate with unsubstituted `{2025}`/`{Joshua Mykitta}` braces; it is now the full canonical Apache-2.0 text (fetched verbatim from apache.org). `NOTICE` braces fixed; it carries the copyright, keeping `LICENSE` byte-canonical for GitHub's license detection.
- **CONTEXT.md**: adds **Estimate** to the worksheet vocabulary — the term the whole legal surface hinges on.

## Design notes
- All legal copy is deliberately **state-agnostic** ("your state's guidelines", never "Alabama's") so multi-state expansion never touches this page.
- `/terms` is intentionally *not* added to `AnalyticsRules.ExcludedPrefixes` — it's counted as a page view exactly like `/privacy`.

## Verification
- `dotnet build`: 0 warnings, 0 errors
- `dotnet test`: 236/236 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)