### PR TITLE
feat: render a real homepage for anonymous visitors and non-JS crawlers

### DIFF
--- a/src/FairShare.Api/Controllers/CatalogController.cs
+++ b/src/FairShare.Api/Controllers/CatalogController.cs
@@ -9,7 +9,10 @@ namespace FairShare.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/states")]
-[Authorize]
+// Anonymous by design: the catalog is inert public data (state and form names), and the
+// homepage must render its state picker without any session so Google's OAuth verification
+// never sees a login-gated landing page.
+[AllowAnonymous]
 public class CatalogController(IStateGuidelineCatalog catalog) : ControllerBase
 {
     private readonly IStateGuidelineCatalog _catalog = catalog;

--- a/src/FairShare.Tests/Api/AuthEndpointsTests.cs
+++ b/src/FairShare.Tests/Api/AuthEndpointsTests.cs
@@ -67,11 +67,13 @@ public class AuthEndpointsTests : IClassFixture<FairShareApiFactory>
     }
 
     [Fact]
-    public async Task States_WithoutToken_ReturnsUnauthorized()
+    public async Task States_WithoutToken_ReturnsOk()
     {
+        // The catalog is deliberately anonymous so the homepage's state picker renders
+        // without a session (Google OAuth verification: no login-gated landing page).
         HttpResponseMessage response = await _client.GetAsync("api/v1/states");
 
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]

--- a/src/FairShare.Web/Pages/Home.razor
+++ b/src/FairShare.Web/Pages/Home.razor
@@ -1,5 +1,4 @@
 @page "/"
-@attribute [Authorize]
 @using FairShare.Contracts.Catalog
 @inject HttpClient Http
 @inject NavigationManager Navigation
@@ -17,7 +16,13 @@
     </p>
     <h2 class="h5 mb-4 text-center">Choose your state</h2>
 
-    @if (states is null)
+    @if (loadFailed)
+    {
+        <div class="alert alert-warning mx-auto" style="max-width: 640px;" role="alert">
+            Couldn't load the state list. <a href="/" class="alert-link">Reload the page</a> to try again.
+        </div>
+    }
+    else if (states is null)
     {
         <p class="text-center">Loading states...</p>
     }
@@ -49,11 +54,22 @@
 @code {
     private List<StateSummaryDto>? states;
     private string? selectedState;
+    private bool loadFailed;
 
     protected override async Task OnInitializedAsync()
     {
-        states = await Http.GetFromJsonAsync<List<StateSummaryDto>>("api/v1/states");
-        selectedState = states?.FirstOrDefault()?.State;
+        // This page is deliberately anonymous (no [Authorize]) - Google's OAuth verification
+        // rejects a homepage that can collapse into a login redirect, so the landing must
+        // render even when guest bootstrap or the API is unavailable.
+        try
+        {
+            states = await Http.GetFromJsonAsync<List<StateSummaryDto>>("api/v1/states");
+            selectedState = states?.FirstOrDefault()?.State;
+        }
+        catch (HttpRequestException)
+        {
+            loadFailed = true;
+        }
     }
 
     private void Continue()

--- a/src/FairShare.Web/Pages/Home.razor
+++ b/src/FairShare.Web/Pages/Home.razor
@@ -66,8 +66,10 @@
             states = await Http.GetFromJsonAsync<List<StateSummaryDto>>("api/v1/states");
             selectedState = states?.FirstOrDefault()?.State;
         }
-        catch (HttpRequestException)
+        catch (Exception)
         {
+            // Deliberately broad: any load failure (network, 401, malformed JSON, timeout)
+            // must degrade to the retry alert, never the global unhandled-error UI.
             loadFailed = true;
         }
     }

--- a/src/FairShare.Web/wwwroot/index.html
+++ b/src/FairShare.Web/wwwroot/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="FairShare is a free child-support calculator: transparent, line-by-line estimates under your state's official guidelines, matching the court's own worksheets." />
     <title>FairShare</title>
     <base href="/" />
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
@@ -16,7 +17,20 @@
 
 <body>
     <div id="app">
-        <div class="d-flex justify-content-center align-items-center" style="height: 100vh;">
+        <!-- Real content, not just a spinner: crawlers and reviewers that don't run
+             JavaScript (Google's OAuth verification among them) must still see the app
+             name, its purpose, and a privacy-policy link. Blazor replaces this on boot. -->
+        <div class="container my-5 text-center">
+            <h1 class="h3 mb-2">FairShare</h1>
+            <p class="lead mx-auto mb-3" style="max-width: 640px;">
+                A free child-support calculator: transparent, line-by-line estimates under your
+                state's official guidelines, matching the court's own worksheets.
+            </p>
+            <p class="mb-4">
+                <a href="/privacy">Privacy Policy</a> &middot;
+                <a href="/terms">Terms of Use</a> &middot;
+                <a href="/support">Support</a>
+            </p>
             <div class="spinner-border text-primary" role="status">
                 <span class="visually-hidden">Loading...</span>
             </div>

--- a/src/FairShare.Web/wwwroot/robots.txt
+++ b/src/FairShare.Web/wwwroot/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /admin/
+Disallow: /account
+
+Sitemap: https://easychildsupport.fyi/sitemap.xml

--- a/src/FairShare.Web/wwwroot/sitemap.xml
+++ b/src/FairShare.Web/wwwroot/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://easychildsupport.fyi/</loc></url>
+  <url><loc>https://easychildsupport.fyi/States/AL</loc></url>
+  <url><loc>https://easychildsupport.fyi/privacy</loc></url>
+  <url><loc>https://easychildsupport.fyi/terms</loc></url>
+  <url><loc>https://easychildsupport.fyi/support</loc></url>
+</urlset>


### PR DESCRIPTION
Closes #118

Google's OAuth verification (Trust & Safety homepage requirements) reviews the page as served, without JavaScript. FairShare's homepage was an empty WASM loading shell, and the `[Authorize]` attribute on `/` could turn the landing into a login redirect — a literal rejection reason.

- **`Home.razor`**: drop `[Authorize]`; the landing (name, purpose, state picker) renders for truly-anonymous visitors. A failed state-list load now shows a reload alert instead of surfacing the unhandled-error toast. Save/profile features remain gated as before.
- **`CatalogController`**: `[AllowAnonymous]` — the catalog is inert public data (state/form names) and the anonymous state picker needs it. Companion test flipped from expecting 401 to 200.
- **`index.html`**: real static content inside the app div (app name, purpose sentence, privacy/terms/support links) + `meta description`; Blazor replaces it on boot, non-JS clients keep it.
- **`robots.txt` / `sitemap.xml`**: added, admin/account disallowed.

All 236 tests pass. Sequencing: deploy before continuing Google verification so the next automated/human review pass sees a conforming page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)