### PR TITLE
docs: record Oregon expansion decisions (glossary + ADRs 0005/0006)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,28 @@ The ubiquitous language of the FairShare domain: child-support worksheets as the
 | **Payer** | The parent the recommended order applies to. "No net transfer" means neither parent owes the other. |
 | **Custodial parent** | On CS-42, the parent with primary physical custody; the other parent is the payer. CS-42-S has no custodial parent. |
 
+## Oregon vocabulary (OAR 137-050)
+
+| Term | Meaning |
+|---|---|
+| **OAR 137-050** | Oregon's child-support guideline rules (division 50, 137-050-0700 through -0765), published by the Oregon DOJ; the source Oregon estimates mirror. |
+| **Oregon workbook** | The Oregon DOJ's Guidelines Calculator Excel workbook — Oregon's official workbook: the reference implementation Oregon estimates are pinned to. |
+| **Adjusted income** | A parent's income minus union dues, the parent's own health-insurance cost, and spousal support owed, plus spousal support received, minus the non-joint-child deduction. Income shares are computed on it. |
+| **Joint child / Non-joint child** | A joint child is a child of both parents in the calculation. A non-joint child is a parent's other legal child, earning that parent a deduction computed from the scale itself. |
+| **Self-support reserve (Oregon)** | The monthly amount of adjusted income kept back for a parent's own support before any obligation; re-set every July 1 ($1,729 effective 2026-07-01). |
+| **Available income** | Adjusted income minus the self-support reserve; the ceiling a parent's total obligation may not exceed. |
+| **Scale** | Oregon's Obligation Scale: combined adjusted income in $50 brackets to $30,000 × 1–10 children. Between brackets the *lower* row applies — no interpolation; above $30,000 the top row applies, rebuttably. |
+| **Basic support obligation (Oregon)** | The scale amount for the combined adjusted income and number of joint children, divided between the parents by income share. |
+| **Overnight** | The unit of parenting time: an average annual count per parent over two years, with half-day equivalents for schedules without overnights. |
+| **Parenting time credit** | The credit against a parent's obligation that grows continuously with their overnights (a logistic curve — no cliff thresholds), applied only to the minor children's portion. |
+| **Child Attending School (CAS)** | An unmarried joint child aged 18–20 in school at least half time. Counted in the obligation, excluded from the parenting-time-credit base, and paid their share of support directly. |
+| **Medical support** | The health-coverage part of an order: who provides the children's coverage, each parent's share of its cost, or **cash medical support** when neither parent has coverage available. |
+| **Reasonable in cost** | The cap on a parent's medical-support contribution: 4% of that parent's adjusted income, and $0 for a parent earning at or below full-time highest Oregon minimum wage. |
+| **Minimum order (Oregon)** | The rebuttable presumption that an obligor can pay at least $100 a month in total support, with defined $0 exceptions (e.g. incarceration, disability benefits as sole income). |
+| **Rebuttal factor** | One of the OAR 137-050-0760 grounds a court may use to move an order away from the guideline amount. |
+| **Agreed support amount** | A stipulated order within ±15% of the guideline amount, presumed just and appropriate. |
+| **Rule version** | The effective date of the guideline rules an estimate implements (e.g. "OAR 137-050 effective 2026-07-01"). Every Oregon estimate and every Scenario names its rule version. |
+
 ## Access vocabulary
 
 | Term | Meaning |
@@ -45,6 +67,7 @@ The ubiquitous language of the FairShare domain: child-support worksheets as the
 | **User / Admin** | Signed-in accounts — a user signs in with an outside identity provider (or is admin-provisioned); an account is free. A user additionally saves parent profiles; an admin additionally manages accounts. |
 | **Guest work** | A guest's in-progress calculation. It lives only in their browser and is never stored unless they sign in and choose to save it. |
 | **Gated feature** | A capability reserved for users (e.g. saving a profile). The moment a guest reaches one is the invitation to sign in. |
+| **Scenario** | A named, saved snapshot of one worksheet's inputs for a state and form, stamped with the rule version and the result they produced. Never call this a "case" — only a court has cases. |
 
 ## Observability vocabulary
 

--- a/docs/adr/0005-per-state-obligation-schedule.md
+++ b/docs/adr/0005-per-state-obligation-schedule.md
@@ -1,0 +1,31 @@
+# ADR 0005 — Each calculator resolves its own state's obligation schedule
+
+**Status:** Accepted — 2026-08-22
+
+## Context
+
+The shared `BaseChildSupportCalculator` calls Alabama's schedule directly and unconditionally: `BcsoLookup` is a static, Alabama-only class, the base `Calculate()` validates every form's child count against Alabama's 1–6 range, and the above-ceiling error message names "the Alabama schedule ($30,000)" regardless of form. That was invisible while Alabama was the only state.
+
+Oregon (the second state, per OAR 137-050) breaks every one of those assumptions, and not just with different numbers — the *semantics* differ:
+
+- Oregon's scale covers 1–10 children (more than 10 uses the 10-child column); Alabama's schedule covers 1–6.
+- Between brackets, Alabama rounds combined income to the nearest $50 row (`MAX(250, ROUND(cagi/50)*50)`); Oregon drops to the **lower** bracket, never rounding up.
+- Above the top bracket, Alabama's guidelines leave support to the court, so FairShare raises `INCOME_ABOVE_SCHEDULE` (ADR 0001); Oregon **caps at the $30,000 row** and continues, rebuttably.
+- Oregon's bottom rows are a flat $50 for any child count; Alabama floors to the $250 row.
+
+## Decision
+
+Obligation-schedule lookup becomes a per-state abstraction that each calculator resolves, supplying its own table data, child-count range, bracket-selection semantics, and above-ceiling behavior (error vs. cap). The base calculator keeps only the state-agnostic worksheet flow; schedule-boundary validation messages come from the state's schedule, not from shared code. Alabama's behavior must not change — the existing golden and workbook-oracle suites are the proof.
+
+The stale Alabama-flavored defaults in shared types (`CalculationResult.State/Form`) and the UI's `CS42` fallback leave shared code in the same refactor.
+
+## Consequences
+
+- Adding a state becomes purely additive: schedule data + calculator class + DI registration, with no base-class edits.
+- Bracket-selection and ceiling semantics live next to the state that owns them, where a reviewer can check them against that state's rule text.
+- The `States`/`Forms` enums widen per state, as `src/FairShare.Domain/README.md` already prescribes.
+
+## Alternatives considered
+
+- **Branch by state inside the base class.** Grows a conditional per state and keeps every state's semantics tangled in one method; exactly the shape that produced the "Alabama schedule" error message on non-Alabama forms.
+- **One merged lookup with unified semantics.** There are no unified semantics to implement — nearest-row vs. lower-row selection and error vs. cap at the ceiling are contradictory by rule, so a shared implementation must falsify at least one state.

--- a/docs/adr/0006-scenario-recompute-with-notice.md
+++ b/docs/adr/0006-scenario-recompute-with-notice.md
@@ -1,0 +1,25 @@
+# ADR 0006 — Scenarios store inputs plus a stamped snapshot, and recompute with notice
+
+**Status:** Accepted — 2026-08-22
+
+## Context
+
+Scenarios (named, saved worksheet-input snapshots — see CONTEXT.md) are FairShare's first persisted user data tied to a state and form; parent profiles are deliberately state-agnostic financial figures. The complication is that guideline rules move under saved data on a statutory schedule: Oregon re-sets its self-support reserve every July 1, so a scenario saved in June computes a different number in July under rules that are both "correct." Users bring these numbers to mediation and court; a saved number that silently changes — or one that is silently stale — is a trust failure either way.
+
+## Decision
+
+A Scenario stores its full worksheet inputs, the rule version it was computed under (the guideline effective date, e.g. "OAR 137-050 effective 2026-07-01"), and a snapshot of the result it produced. Reopening a scenario always recomputes under the **current** rules; when the recomputed result differs from the snapshot, the UI says so explicitly, showing both the saved and current figures and why they differ (rule version changed). FairShare calculates under current rules only — it does not maintain historical rule sets to re-run old versions.
+
+The schema is state-agnostic from day one so Alabama scenarios adopt it unchanged.
+
+## Consequences
+
+- Scenario lists render from stored snapshots — no recompute fan-out to display them.
+- Every state needs its rule parameters keyed by effective date so the stamp exists to compare against (Oregon's self-support reserve is the first annually-moving one).
+- A reopened scenario is honest in both directions: the user keeps the number they saved *and* learns what today's rules say.
+
+## Alternatives considered
+
+- **Inputs only, silent recompute.** The number a user quoted in mediation moves without explanation the next July 1.
+- **Frozen result, never recompute.** Permanently stale; useless for the planning and what-if purpose scenarios exist for.
+- **Full historical rule engines.** Would let old scenarios re-run under their original rules, but courts apply current rules to new calculations; the snapshot preserves the historical number at a fraction of the cost.


### PR DESCRIPTION
Decision records from the Oregon (OAR 137-050) design session — no code changes.

- **CONTEXT.md**: new *Oregon vocabulary (OAR 137-050)* section (adjusted income, available income, scale, overnights, parenting time credit, Child Attending School, medical support, reasonable in cost, minimum order, rebuttal factor, agreed support amount, rule version) and **Scenario** added to the Access vocabulary.
- **ADR 0005** — each calculator resolves its own state's obligation schedule: AL and OR disagree on bracket selection (nearest row vs. lower row) and ceiling behavior (error vs. cap), so the static `BcsoLookup` coupling in the base calculator becomes a per-state abstraction. Alabama behavior unchanged, proven by the existing golden/oracle suites.
- **ADR 0006** — Scenarios store inputs + rule-version stamp + result snapshot, recompute under current rules on open, and show a notice when the result moved (Oregon's self-support reserve changes every July 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)