### PR TITLE
refactor: per-state obligation schedule abstraction (ADR 0005)

### DIFF
--- a/src/FairShare.Domain/Calculators/BaseChildSupportCalculator.cs
+++ b/src/FairShare.Domain/Calculators/BaseChildSupportCalculator.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using FairShare.Domain.Helpers;
 using FairShare.Domain.Interfaces;
 using FairShare.Domain.Models;
-using FairShare.Domain.Seeds;
 using Microsoft.Extensions.Logging;
 using static FairShare.Domain.Helpers.Enums;
 
@@ -28,6 +27,12 @@ namespace FairShare.Domain.Calculators
         public abstract string Description { get; }
 
         /// <summary>
+        /// The state's schedule of basic obligations. Child-count bounds, bracket selection and
+        /// above-ceiling behavior all come from here — the template stays state-agnostic (ADR 0005).
+        /// </summary>
+        protected abstract IObligationSchedule Schedule { get; }
+
+        /// <summary>
         /// Shared custody flag; override in derived calculators that implement shared custody rules.
         /// </summary>
         public virtual bool IsSharedCustody => false;
@@ -36,10 +41,10 @@ namespace FairShare.Domain.Calculators
         {
             CalculationResult result = CreateResultShell(numberOfChildren);
 
-            if (numberOfChildren < BcsoLookup.MinChildren || numberOfChildren > BcsoLookup.MaxChildren)
+            if (numberOfChildren < Schedule.MinChildren || numberOfChildren > Schedule.MaxChildren)
             {
                 AddError(result, CalcErrorCodes.InvalidChildCount,
-                    $"Number of children must be between {BcsoLookup.MinChildren} and {BcsoLookup.MaxChildren}.",
+                    $"Number of children must be between {Schedule.MinChildren} and {Schedule.MaxChildren}.",
                     nameof(numberOfChildren));
                 return result;
             }
@@ -56,10 +61,8 @@ namespace FairShare.Domain.Calculators
             }
             catch (IncomeAboveScheduleException ex)
             {
-                AddError(result, CalcErrorCodes.IncomeAboveSchedule,
-                    $"Combined adjusted gross income of ${ex.CombinedAdjustedGrossIncome:N0} is above the top of the Alabama schedule " +
-                    $"(${BcsoLookup.ScheduleCeiling:N0}); support above the schedule is left to the court's discretion.",
-                    "CombinedAdjustedGrossIncome");
+                // The schedule words this message in its own state's terms (ADR 0005).
+                AddError(result, CalcErrorCodes.IncomeAboveSchedule, ex.Message, "CombinedAdjustedGrossIncome");
                 _logger.LogWarning(ex, "Income above schedule in {Form} calculation.", Form);
             }
             catch (Exception ex)
@@ -141,8 +144,8 @@ namespace FairShare.Domain.Calculators
         /// <summary>
         /// The schedule amount for the combined adjusted gross income (worksheet line 4).
         /// </summary>
-        protected static int GetBasicChildSupportObligation(int numberOfChildren, int combinedAdjustedGrossIncome)
-            => BcsoLookup.Get(combinedAdjustedGrossIncome, numberOfChildren);
+        protected int GetBasicChildSupportObligation(int numberOfChildren, int combinedAdjustedGrossIncome)
+            => Schedule.GetBasicObligation(combinedAdjustedGrossIncome, numberOfChildren);
 
         protected CalculationResult CreateResultShell(int numberOfChildren)
             => new(string.Empty, 0)

--- a/src/FairShare.Domain/Calculators/CS42Calculator.cs
+++ b/src/FairShare.Domain/Calculators/CS42Calculator.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FairShare.Domain.Helpers;
+using FairShare.Domain.Interfaces;
 using FairShare.Domain.Models;
+using FairShare.Domain.Seeds;
 using Microsoft.Extensions.Logging;
 using static FairShare.Domain.Helpers.Enums;
 
@@ -30,6 +32,8 @@ namespace FairShare.Domain.Calculators
         public override string DisplayName => "CS-42 (Rev. 5/2022)";
         public override string Description => "Standard custody";
         public override bool IsSharedCustody => false;
+
+        protected override IObligationSchedule Schedule => AlabamaObligationSchedule.Instance;
 
         protected override WorksheetOutcome BuildWorksheet(WorksheetBuilder worksheet, ParentData plaintiff, ParentData defendant, int numberOfChildren)
         {

--- a/src/FairShare.Domain/Calculators/CS42SCalculator.cs
+++ b/src/FairShare.Domain/Calculators/CS42SCalculator.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FairShare.Domain.Helpers;
+using FairShare.Domain.Interfaces;
 using FairShare.Domain.Models;
+using FairShare.Domain.Seeds;
 using Microsoft.Extensions.Logging;
 using static FairShare.Domain.Helpers.Enums;
 
@@ -28,6 +30,8 @@ namespace FairShare.Domain.Calculators
         public override string DisplayName => "CS-42-S (Eff. 6/2023)";
         public override string Description => "Shared 50/50 physical custody";
         public override bool IsSharedCustody => true;
+
+        protected override IObligationSchedule Schedule => AlabamaObligationSchedule.Instance;
 
         protected override WorksheetOutcome BuildWorksheet(WorksheetBuilder worksheet, ParentData plaintiff, ParentData defendant, int numberOfChildren)
         {

--- a/src/FairShare.Domain/Helpers/CalculationResult.cs
+++ b/src/FairShare.Domain/Helpers/CalculationResult.cs
@@ -25,12 +25,12 @@ namespace FairShare.Domain.Helpers
         /// <summary>
         /// Gets or sets the two-letter abbreviation for the state this calculator is designed for.
         /// </summary>
-        public string State { get; set; } = "AL";
+        public string State { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the specific form or guideline this calculator implements within the state.
         /// </summary>
-        public string Form { get; set; } = "CS42S";
+        public string Form { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the number of children shared between both parents in the child support order.

--- a/src/FairShare.Domain/Helpers/IncomeAboveScheduleException.cs
+++ b/src/FairShare.Domain/Helpers/IncomeAboveScheduleException.cs
@@ -3,12 +3,13 @@ using System;
 namespace FairShare.Domain.Helpers
 {
     /// <summary>
-    /// Thrown by the schedule lookup when the combined adjusted gross income rounds to a $50 bracket above the
-    /// top of the Basic Child-Support Obligation schedule. Calculators translate it into an
+    /// Thrown by a schedule lookup whose guidelines leave income above the schedule's top bracket to
+    /// the court. The throwing schedule words <paramref name="message"/> in its own state's terms
+    /// (ADR 0005); calculators surface it verbatim as a
     /// <see cref="CalcErrorCodes.IncomeAboveSchedule"/> error on the result.
     /// </summary>
-    public sealed class IncomeAboveScheduleException(int combinedAdjustedGrossIncome)
-        : Exception($"Combined adjusted gross income of {combinedAdjustedGrossIncome} is above the top of the schedule.")
+    public sealed class IncomeAboveScheduleException(int combinedAdjustedGrossIncome, string message)
+        : Exception(message)
     {
         /// <summary>
         /// The combined adjusted gross income (worksheet line 2, combined) that fell above the schedule.

--- a/src/FairShare.Domain/Interfaces/IObligationSchedule.cs
+++ b/src/FairShare.Domain/Interfaces/IObligationSchedule.cs
@@ -1,0 +1,28 @@
+using FairShare.Domain.Helpers;
+
+namespace FairShare.Domain.Interfaces
+{
+    /// <summary>
+    /// A state's schedule (or scale) of basic child-support obligations: its table data, the child
+    /// counts it has columns for, its bracket-selection semantics, and what happens above its top
+    /// bracket. These contradict between states (Alabama rounds to the nearest $50 row and errors
+    /// above its ceiling; Oregon drops to the lower row and caps), so per ADR 0005 each lives with
+    /// the state that owns it — never in shared calculator code.
+    /// </summary>
+    public interface IObligationSchedule
+    {
+        /// <summary>Fewest children the schedule has a column for.</summary>
+        int MinChildren { get; }
+
+        /// <summary>Most children the schedule has a column for.</summary>
+        int MaxChildren { get; }
+
+        /// <summary>
+        /// The monthly basic obligation for a combined income and child count, using this state's
+        /// bracket-selection and ceiling semantics. A schedule whose guidelines leave above-ceiling
+        /// incomes to the court throws <see cref="IncomeAboveScheduleException"/> carrying a message
+        /// in that state's own words.
+        /// </summary>
+        int GetBasicObligation(int combinedIncome, int children);
+    }
+}

--- a/src/FairShare.Domain/README.md
+++ b/src/FairShare.Domain/README.md
@@ -5,11 +5,11 @@ The pure calculation engine. No ASP.NET, no EF, no Identity — just determinist
 ## Layout
 
 - `Calculators/`
-  - `BaseChildSupportCalculator` — the template: validates the child count, runs the form's `BuildWorksheet`, maps `IncomeAboveScheduleException` / unexpected failures to `CalcError`s, and provides the Excel-faithful helpers (`ExcelRound`, `ExcelRound2`, `ShareOfIncome`, `AddIncomeLines` for lines 1–2).
+  - `BaseChildSupportCalculator` — the template: validates the child count against the form's `Schedule`, runs the form's `BuildWorksheet`, maps `IncomeAboveScheduleException` / unexpected failures to `CalcError`s, and provides the Excel-faithful helpers (`ExcelRound`, `ExcelRound2`, `ShareOfIncome`, `AddIncomeLines` for lines 1–2). It is state-agnostic: schedule data, child-count bounds and above-ceiling behavior all come from the calculator's `IObligationSchedule` (ADR 0005).
   - `WorksheetBuilder` — collects `WorksheetLine`s in form order.
   - `CS42Calculator` — Alabama CS-42 (Rev. 5/2022, standard custody), lines 1–13.
   - `CS42SCalculator` — Alabama CS-42-S (Eff. 6/2023, shared 50/50 physical custody), lines 1–14.
-- `Seeds/BcsoLookup.cs` — Alabama's Schedule of Basic Child-Support Obligations ("AL Realigned Sept 2021"). `Get(cagi, children)` reproduces the workbook's lookup: `MAX(250, ROUND(cagi/50)*50)`, halves away from zero; a bracket above $30,000 throws `IncomeAboveScheduleException`.
+- `Seeds/` — per-state schedule data. `BcsoLookup.cs` is Alabama's Schedule of Basic Child-Support Obligations ("AL Realigned Sept 2021"): `Get(cagi, children)` reproduces the workbook's lookup — `MAX(250, ROUND(cagi/50)*50)`, halves away from zero; a bracket above $30,000 throws `IncomeAboveScheduleException` with Alabama's wording. `AlabamaObligationSchedule` exposes it through `IObligationSchedule` for the two Alabama forms.
 - `Models/ParentData.cs` — plain input model (income, preexisting support/alimony, childcare and healthcare costs, custody flag).
 - `Helpers/` — `CalculationResult` (success flag, payer, final amount, `Lines`), `WorksheetLine` (number/label/plaintiff/defendant/combined/format), `CalcError` + `CalcErrorCodes`, `FormInfo` (catalog summary), shared enums.
 - `Interfaces/` + `Services/StateGuidelineCatalog.cs` — `IChildSupportCalculator` is the contract every worksheet implements (`State`, `Form`, `DisplayName`, `Description`, `IsSharedCustody`, `Calculate`); the catalog maps `(state, form)` → calculator and backs the API's `/states` endpoints.
@@ -20,9 +20,10 @@ The official AOC Excel workbook for a form is the reference implementation (see 
 
 ## Adding a new state or form
 
-1. Extend `BaseChildSupportCalculator`: set `State`/`Form`/`DisplayName`/`Description`, and implement `BuildWorksheet` line by line against the form's official workbook.
-2. Register it in DI (see the "Domain services" block in `FairShare.Api/Program.cs`) — `StateGuidelineCatalog` discovers calculators from DI, and the new form shows up in the catalog endpoints automatically.
-3. Add golden cases in `FairShare.Tests/Domain/Golden/` whose expected values are read back from that form's official workbook (see `Generate-GoldenCases.ps1`), plus targeted unit tests in `FairShare.Tests/Domain/`.
+1. For a new state, implement its `IObligationSchedule` in `Seeds/` with that state's table data, child-count range, bracket-selection semantics and above-ceiling behavior (error vs. cap — see ADR 0005; the two contradict between states, so never share them).
+2. Extend `BaseChildSupportCalculator`: set `State`/`Form`/`DisplayName`/`Description`, point `Schedule` at the state's schedule, and implement `BuildWorksheet` line by line against the form's official workbook.
+3. Register it in DI (see the "Domain services" block in `FairShare.Api/Program.cs`) — `StateGuidelineCatalog` discovers calculators from DI, and the new form shows up in the catalog endpoints automatically.
+4. Add golden cases in `FairShare.Tests/Domain/Golden/` whose expected values are read back from that form's official workbook (see `Generate-GoldenCases.ps1`), plus targeted unit tests in `FairShare.Tests/Domain/`.
 
 ## Rules
 

--- a/src/FairShare.Domain/Seeds/AlabamaObligationSchedule.cs
+++ b/src/FairShare.Domain/Seeds/AlabamaObligationSchedule.cs
@@ -1,0 +1,25 @@
+using FairShare.Domain.Interfaces;
+
+namespace FairShare.Domain.Seeds
+{
+    /// <summary>
+    /// Alabama's schedule behind <see cref="IObligationSchedule"/>: <see cref="BcsoLookup"/>'s data
+    /// and lookup semantics (nearest-$50 bracket, $250 floor, error above $30,000 per ADR 0001),
+    /// shared by both Alabama forms.
+    /// </summary>
+    public sealed class AlabamaObligationSchedule : IObligationSchedule
+    {
+        public static readonly AlabamaObligationSchedule Instance = new();
+
+        private AlabamaObligationSchedule()
+        {
+        }
+
+        public int MinChildren => BcsoLookup.MinChildren;
+
+        public int MaxChildren => BcsoLookup.MaxChildren;
+
+        public int GetBasicObligation(int combinedIncome, int children)
+            => BcsoLookup.Get(combinedIncome, children);
+    }
+}

--- a/src/FairShare.Domain/Seeds/BcsoLookup.cs
+++ b/src/FairShare.Domain/Seeds/BcsoLookup.cs
@@ -54,7 +54,9 @@ namespace FairShare.Domain.Seeds
 
             if (key > ScheduleCeiling)
             {
-                throw new IncomeAboveScheduleException(combinedAdjustedGrossIncome);
+                throw new IncomeAboveScheduleException(combinedAdjustedGrossIncome,
+                    $"Combined adjusted gross income of ${combinedAdjustedGrossIncome:N0} is above the top of the Alabama schedule " +
+                    $"(${ScheduleCeiling:N0}); support above the schedule is left to the court's discretion.");
             }
 
             return Table[(key, children)];

--- a/src/FairShare.Tests/Domain/AlabamaObligationScheduleTests.cs
+++ b/src/FairShare.Tests/Domain/AlabamaObligationScheduleTests.cs
@@ -1,0 +1,33 @@
+using FairShare.Domain.Helpers;
+using FairShare.Domain.Seeds;
+
+namespace FairShare.Tests.Domain;
+
+public class AlabamaObligationScheduleTests
+{
+    [Fact]
+    public void Bounds_MatchTheAlabamaSchedule()
+    {
+        Assert.Equal(BcsoLookup.MinChildren, AlabamaObligationSchedule.Instance.MinChildren);
+        Assert.Equal(BcsoLookup.MaxChildren, AlabamaObligationSchedule.Instance.MaxChildren);
+    }
+
+    [Theory]
+    [InlineData(250, 1)]
+    [InlineData(5000, 3)]
+    [InlineData(30000, 6)]
+    public void GetBasicObligation_DelegatesToBcsoLookup(int cagi, int children)
+    {
+        Assert.Equal(BcsoLookup.Get(cagi, children), AlabamaObligationSchedule.Instance.GetBasicObligation(cagi, children));
+    }
+
+    [Fact]
+    public void GetBasicObligation_AboveCeiling_ThrowsWithAlabamaWording()
+    {
+        IncomeAboveScheduleException ex = Assert.Throws<IncomeAboveScheduleException>(
+            () => AlabamaObligationSchedule.Instance.GetBasicObligation(30025, 2));
+
+        Assert.Equal(30025, ex.CombinedAdjustedGrossIncome);
+        Assert.Contains("Alabama schedule", ex.Message);
+    }
+}

--- a/src/FairShare.Web/Pages/Calculator.razor
+++ b/src/FairShare.Web/Pages/Calculator.razor
@@ -245,11 +245,10 @@
     // Export follows a successful calculation (and recalculates again right before exporting, see ExportAsync).
     private bool CanExport => submitted && result is { Success: true };
 
-    // Until the catalog answers, fall back to the one form we know needs a custodial parent.
+    // Until the catalog answers we show no custody requirement rather than guessing from a
+    // hardcoded form name — shared UI carries no state or form specifics (ADR 0005).
     private bool RequiresPrimaryCustody =>
-        CurrentForm is { } current
-            ? !current.IsSharedCustody
-            : string.Equals(Form, "CS42", StringComparison.OrdinalIgnoreCase);
+        CurrentForm is { } current && !current.IsSharedCustody;
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
Closes #126 · Implements [ADR 0005](docs/adr/0005-per-state-obligation-schedule.md)

First step of the Oregon expansion: the base calculator becomes state-agnostic.

- **`IObligationSchedule`** — a state's schedule behind an interface: child-count bounds and the basic-obligation lookup with that state's bracket-selection and above-ceiling semantics. AL and OR contradict on both (nearest-row vs. lower-row; error vs. cap), so no shared implementation can be right for both.
- **`AlabamaObligationSchedule`** wraps `BcsoLookup` unchanged; both AL calculators point `Schedule` at it.
- **`IncomeAboveScheduleException`** now carries the throwing schedule's message; `BcsoLookup` words Alabama's ("above the top of the Alabama schedule ($30,000)…"), and the base class surfaces it verbatim — no state wording in shared code.
- **Leak cleanup**: `CalculationResult` loses its stale `"AL"`/`"CS42S"` defaults; `Calculator.razor` drops the hardcoded `CS42` custody fallback (no custody prompt until the catalog answers).
- **Domain README**: add-a-state checklist gains the schedule step.

**No behavior change for Alabama**: full suite green — 241 tests including all golden cases and the workbook-oracle tests (5 new tests for the schedule wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)