### PR TITLE
feat: wire the Oregon worksheet into the catalog and calculations API

### DIFF
--- a/src/FairShare.Api/Controllers/CalculationsController.cs
+++ b/src/FairShare.Api/Controllers/CalculationsController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FairShare.Api.Observability;
 using FairShare.Api.Services.Export;
 using FairShare.Contracts.Calculation;
+using FairShare.Domain.Calculators;
 using FairShare.Domain.Helpers;
 using FairShare.Domain.Interfaces;
 using FairShare.Domain.Models;
@@ -24,9 +25,9 @@ public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetEx
     [HttpPost]
     public async Task<ActionResult<CalculationResponse>> Calculate(string state, string form, [FromBody] CalculationRequest request, CancellationToken ct)
     {
-        IChildSupportCalculator? calculator = _catalog.GetCalculator(state, form);
+        IWorksheetForm? formEntry = _catalog.GetForm(state, form);
 
-        if (calculator is null)
+        if (formEntry is null)
         {
             return NotFound(new { message = $"No calculator registered for {state}/{form}." });
         }
@@ -36,10 +37,41 @@ public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetEx
         string eventTarget = $"{state}/{form}".ToLowerInvariant();
         await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationStarted, eventTarget, ct);
 
-        ParentData plaintiff = ToParentData(request.Plaintiff);
-        ParentData defendant = ToParentData(request.Defendant);
+        CalculationResult result;
 
-        CalculationResult result = calculator.Calculate(plaintiff, defendant, request.NumberOfChildren);
+        if (formEntry is IChildSupportCalculator calculator)
+        {
+            ParentData plaintiff = ToParentData(request.Plaintiff);
+            ParentData defendant = ToParentData(request.Defendant);
+
+            result = calculator.Calculate(plaintiff, defendant, request.NumberOfChildren);
+        }
+        else if (formEntry is OregonWorksheetCalculator oregonCalculator)
+        {
+            if (request.Oregon is null)
+            {
+                return BadRequest(new { message = $"{state}/{form} requires the request's 'oregon' inputs." });
+            }
+
+            if (!TryMapOregonInput(request.Oregon, out OregonWorksheetInput? oregonInput, out string? mappingError))
+            {
+                return BadRequest(new { message = mappingError });
+            }
+
+            OregonCalculationOutcome outcome = oregonCalculator.Calculate(oregonInput!);
+            result = ToCalculationResult(oregonCalculator, request.Oregon, outcome);
+
+            if (outcome.Success)
+            {
+                await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationCompleted, eventTarget, ct);
+            }
+
+            return Ok(ToResponse(result, ToOregonDto(outcome)));
+        }
+        else
+        {
+            return NotFound(new { message = $"No calculator registered for {state}/{form}." });
+        }
 
         if (result.Success)
         {
@@ -80,9 +112,94 @@ public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetEx
         return File(export.Content, export.ContentType, export.FileName);
     }
 
-    private static CalculationResponse ToResponse(CalculationResult result)
+    /// <summary>
+    /// Folds an Oregon outcome into the shared result shape: the headline payer is line 7c's
+    /// parent (empty when neither pays for the minors) and the headline amount is that parent's
+    /// line 9e total; both parents' totals travel in the Oregon extras.
+    /// </summary>
+    private static CalculationResult ToCalculationResult(OregonWorksheetCalculator calculator, OregonCalculationRequest request, OregonCalculationOutcome outcome)
+        => new(outcome.PaysForMinorChildren?.ToString() ?? string.Empty,
+               (int)(outcome.PaysForMinorChildren switch
+               {
+                   Enums.ParentType.Plaintiff => outcome.PlaintiffTotalSupport,
+                   Enums.ParentType.Defendant => outcome.DefendantTotalSupport,
+                   _ => 0m,
+               }))
+        {
+            Success = outcome.Success,
+            Errors = [.. outcome.Errors],
+            State = calculator.State,
+            Form = calculator.Form,
+            NumberOfChildren = request.JointMinorChildren + request.JointChildrenAttendingSchool,
+            Lines = outcome.Lines,
+        };
+
+    private static OregonResultDto ToOregonDto(OregonCalculationOutcome outcome)
         => new()
         {
+            PlaintiffTotalSupport = outcome.PlaintiffTotalSupport,
+            DefendantTotalSupport = outcome.DefendantTotalSupport,
+            PaysForMinorChildren = outcome.PaysForMinorChildren?.ToString(),
+            CoverageProvider = outcome.CoverageProvider.ToString(),
+            ReasonableCostTotal = outcome.ReasonableCostTotal,
+            RuleEffectiveDate = outcome.RuleEffectiveDate.ToString("yyyy-MM-dd"),
+        };
+
+    private static bool TryMapOregonInput(OregonCalculationRequest dto, out OregonWorksheetInput? input, out string? error)
+    {
+        input = null;
+
+        if (!Enum.TryParse(dto.CashMedical, ignoreCase: true, out CashMedicalElection cashMedical))
+        {
+            error = "cashMedical must be \"No\", \"Yes\", or \"Contingent\".";
+            return false;
+        }
+
+        CoverageProvider? selection = null;
+        if (dto.CoverageSelection is { } selectionText)
+        {
+            if (!Enum.TryParse(selectionText, ignoreCase: true, out CoverageProvider parsed))
+            {
+                error = "coverageSelection must be \"Plaintiff\", \"Defendant\", \"Both\", or \"EitherWhenAvailable\".";
+                return false;
+            }
+
+            selection = parsed;
+        }
+
+        input = new OregonWorksheetInput
+        {
+            Plaintiff = ToOregonParent(dto.Plaintiff),
+            Defendant = ToOregonParent(dto.Defendant),
+            JointMinorChildren = dto.JointMinorChildren,
+            JointChildrenAttendingSchool = dto.JointChildrenAttendingSchool,
+            CashMedical = cashMedical,
+            CoverageSelection = selection,
+            OrderCoverageAtHigherAmount = dto.OrderCoverageAtHigherAmount,
+        };
+        error = null;
+        return true;
+    }
+
+    private static OregonParentInput ToOregonParent(OregonParentDto dto) => new()
+    {
+        MonthlyIncome = dto.MonthlyIncome,
+        SpousalSupportReceived = dto.SpousalSupportReceived,
+        SpousalSupportPaid = dto.SpousalSupportPaid,
+        UnionDues = dto.UnionDues,
+        OwnHealthInsuranceCost = dto.OwnHealthInsuranceCost,
+        NonJointChildren = dto.NonJointChildren,
+        ChildCareCosts = dto.ChildCareCosts,
+        ChildrensHealthCoverageCost = dto.ChildrensHealthCoverageCost,
+        AverageOvernights = dto.AverageOvernights,
+        SocialSecurityVeteransBenefits = dto.SocialSecurityVeteransBenefits,
+        MinimumOrderException = dto.MinimumOrderException,
+    };
+
+    private static CalculationResponse ToResponse(CalculationResult result, OregonResultDto? oregon = null)
+        => new()
+        {
+            Oregon = oregon,
             Success = result.Success,
             State = result.State,
             Form = result.Form,

--- a/src/FairShare.Api/Controllers/CalculationsController.cs
+++ b/src/FairShare.Api/Controllers/CalculationsController.cs
@@ -119,12 +119,14 @@ public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetEx
     /// </summary>
     private static CalculationResult ToCalculationResult(OregonWorksheetCalculator calculator, OregonCalculationRequest request, OregonCalculationOutcome outcome)
         => new(outcome.PaysForMinorChildren?.ToString() ?? string.Empty,
-               (int)(outcome.PaysForMinorChildren switch
+               // Line 9e is whole-dollar by construction (9a-9d each round to the dollar), so this
+               // rounding is a guard against truncation, not a change of value.
+               (int)Math.Round(outcome.PaysForMinorChildren switch
                {
                    Enums.ParentType.Plaintiff => outcome.PlaintiffTotalSupport,
                    Enums.ParentType.Defendant => outcome.DefendantTotalSupport,
                    _ => 0m,
-               }))
+               }, 0, MidpointRounding.AwayFromZero))
         {
             Success = outcome.Success,
             Errors = [.. outcome.Errors],

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -234,9 +234,11 @@ builder.Services.Configure<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>
     options.KnownProxies.Clear();
 });
 
-// Domain services
-builder.Services.AddScoped<IChildSupportCalculator, CS42Calculator>();
-builder.Services.AddScoped<IChildSupportCalculator, CS42SCalculator>();
+// Domain services - every worksheet form registers as IWorksheetForm; the catalog narrows the
+// classic two-parent forms back to IChildSupportCalculator itself.
+builder.Services.AddScoped<IWorksheetForm, CS42Calculator>();
+builder.Services.AddScoped<IWorksheetForm, CS42SCalculator>();
+builder.Services.AddScoped<IWorksheetForm, OregonWorksheetCalculator>();
 builder.Services.AddScoped<IStateGuidelineCatalog, StateGuidelineCatalog>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IWorksheetExporter, ClosedXmlWorksheetExporter>();

--- a/src/FairShare.Contracts/Calculation/CalculationContracts.cs
+++ b/src/FairShare.Contracts/Calculation/CalculationContracts.cs
@@ -43,6 +43,76 @@ public class CalculationRequest
 
     [Required]
     public ParentDataDto Defendant { get; set; } = new();
+
+    /// <summary>
+    /// The Oregon worksheet's inputs. Required when calculating an Oregon form; ignored (and the
+    /// classic fields above unused) otherwise.
+    /// </summary>
+    public OregonCalculationRequest? Oregon { get; set; }
+}
+
+/// <summary>One parent's column of the Oregon worksheet. Monthly dollars, cents allowed.</summary>
+public class OregonParentDto
+{
+    [Range(0, double.MaxValue)]
+    public decimal MonthlyIncome { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal SpousalSupportReceived { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal SpousalSupportPaid { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal UnionDues { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal OwnHealthInsuranceCost { get; set; }
+
+    [Range(0, int.MaxValue)]
+    public int NonJointChildren { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal ChildCareCosts { get; set; }
+
+    /// <summary>Cost to enroll the joint children in this parent's coverage; null = no appropriate coverage available.</summary>
+    [Range(0, double.MaxValue)]
+    public decimal? ChildrensHealthCoverageCost { get; set; }
+
+    [Range(0, 365)]
+    public decimal AverageOvernights { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal SocialSecurityVeteransBenefits { get; set; }
+
+    public bool MinimumOrderException { get; set; }
+}
+
+/// <summary>The Oregon worksheet's case-level inputs plus both parents' columns.</summary>
+public class OregonCalculationRequest
+{
+    [Required]
+    public OregonParentDto Plaintiff { get; set; } = new();
+
+    [Required]
+    public OregonParentDto Defendant { get; set; } = new();
+
+    [Range(0, int.MaxValue)]
+    public int JointMinorChildren { get; set; }
+
+    [Range(0, int.MaxValue)]
+    public int JointChildrenAttendingSchool { get; set; }
+
+    /// <summary>"No", "Yes", or "Contingent" (worksheet line 5a).</summary>
+    public string CashMedical { get; set; } = "No";
+
+    /// <summary>
+    /// "Plaintiff", "Defendant", "Both", or "EitherWhenAvailable" (worksheet line 4f); null lets
+    /// the calculator choose per OAR 137-050-0750.
+    /// </summary>
+    public string? CoverageSelection { get; set; }
+
+    public bool OrderCoverageAtHigherAmount { get; set; }
 }
 
 /// <summary>
@@ -67,7 +137,8 @@ public class CalcErrorDto
 
 /// <summary>
 /// One numbered line of the worksheet, with the value shown in each column. A null column means the form has no
-/// cell there. <see cref="Format"/> is "Currency" (whole dollars) or "Percent" (fraction, 0.57 = 57%).
+/// cell there. <see cref="Format"/> is "Currency" (dollar amounts), "Percent" (fraction, 0.57 = 57%),
+/// or "Number" (plain counts - children, overnights).
 /// </summary>
 public class WorksheetLineDto
 {
@@ -93,4 +164,33 @@ public class CalculationResponse
     /// Every worksheet line in form order; empty when <see cref="Success"/> is false.
     /// </summary>
     public List<WorksheetLineDto> Lines { get; set; } = [];
+
+    /// <summary>Oregon-only extras; null for other states' forms.</summary>
+    public OregonResultDto? Oregon { get; set; }
+}
+
+/// <summary>
+/// What Oregon's worksheet produces beyond a single payer and amount: both parents can owe at once
+/// (Children Attending School are paid directly by each parent), and every estimate names the rule
+/// version it implements.
+/// </summary>
+public class OregonResultDto
+{
+    /// <summary>Line 9e for the plaintiff.</summary>
+    public decimal PlaintiffTotalSupport { get; set; }
+
+    /// <summary>Line 9e for the defendant.</summary>
+    public decimal DefendantTotalSupport { get; set; }
+
+    /// <summary>Line 7c: "Plaintiff" or "Defendant", or null when neither should pay for the minors.</summary>
+    public string? PaysForMinorChildren { get; set; }
+
+    /// <summary>Lines 4f/9f: "Plaintiff", "Defendant", "Both", or "EitherWhenAvailable".</summary>
+    public string CoverageProvider { get; set; } = string.Empty;
+
+    /// <summary>Line 9g: the reasonable cost cap to name in the order.</summary>
+    public decimal ReasonableCostTotal { get; set; }
+
+    /// <summary>The OAR 137-050 effective date this estimate implements (ISO date).</summary>
+    public string RuleEffectiveDate { get; set; } = string.Empty;
 }

--- a/src/FairShare.Domain/Calculators/OregonWorksheetCalculator.cs
+++ b/src/FairShare.Domain/Calculators/OregonWorksheetCalculator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using FairShare.Domain.Helpers;
+using FairShare.Domain.Interfaces;
 using FairShare.Domain.Models;
 using FairShare.Domain.Seeds;
 using static FairShare.Domain.Helpers.Enums;
@@ -14,8 +15,14 @@ namespace FairShare.Domain.Calculators
     /// rounds (to 2 or 4 places, or to the dollar) and where it deliberately does not.
     /// The caretaker/state-care variant is not modeled (both-parents cases only).
     /// </summary>
-    public sealed class OregonWorksheetCalculator
+    public sealed class OregonWorksheetCalculator : IWorksheetForm
     {
+        public string State => States.OR.ToString();
+        public string Form => Forms.Worksheet.ToString();
+        public string DisplayName => "Child Support Worksheet (CSF 02 0910)";
+        public string Description => "All custody arrangements; support to age 21 for Children Attending School";
+        public bool IsSharedCustody => false;
+
         public OregonCalculationOutcome Calculate(OregonWorksheetInput input)
             => Calculate(input, OregonRuleParameters.Current);
 

--- a/src/FairShare.Domain/Helpers/Enums.cs
+++ b/src/FairShare.Domain/Helpers/Enums.cs
@@ -34,7 +34,8 @@ namespace FairShare.Domain.Helpers
         /// </summary>
         public enum States
         {
-            AL
+            AL,
+            OR
         }
 
         /// <summary>
@@ -43,7 +44,10 @@ namespace FairShare.Domain.Helpers
         public enum Forms
         {
             CS42,
-            CS42S
+            CS42S,
+
+            /// <summary>Oregon's single Child Support Worksheet (CSF 02 0910).</summary>
+            Worksheet
         }
 
         /// <summary>

--- a/src/FairShare.Domain/Interfaces/IChildSupportCalculator.cs
+++ b/src/FairShare.Domain/Interfaces/IChildSupportCalculator.cs
@@ -8,33 +8,12 @@ using FairShare.Domain.Models;
 
 namespace FairShare.Domain.Interfaces
 {
-    public interface IChildSupportCalculator
+    /// <summary>
+    /// A form whose inputs fit the classic two-parents-plus-child-count shape (both Alabama
+    /// worksheets). Forms with richer inputs (Oregon) implement only <see cref="IWorksheetForm"/>.
+    /// </summary>
+    public interface IChildSupportCalculator : IWorksheetForm
     {
-        /// <summary>
-        /// The two-letter abbreviation for the state this calculator is designed for.
-        /// </summary>
-        string State { get; }
-
-        /// <summary>
-        /// The specific form or guideline this calculator implements within the state.
-        /// </summary>
-        string Form { get; }
-
-        /// <summary>
-        /// Human-readable form name including its revision, e.g. "CS-42 (Rev. 5/2022)".
-        /// </summary>
-        string DisplayName { get; }
-
-        /// <summary>
-        /// One-line description of when the form applies, e.g. "Standard custody".
-        /// </summary>
-        string Description { get; }
-
-        /// <summary>
-        /// Indicates whether this calculator implements a shared custody guideline variant.
-        /// </summary>
-        bool IsSharedCustody { get; }
-
         /// <summary>
         /// Calculates the final child support obligation for both parents and determines which parent is the payer based on the
         /// <see cref="ParentData"/> provided for each parent and the number of children.

--- a/src/FairShare.Domain/Interfaces/IStateGuidelineCatalog.cs
+++ b/src/FairShare.Domain/Interfaces/IStateGuidelineCatalog.cs
@@ -11,6 +11,11 @@ namespace FairShare.Domain.Interfaces
     {
         IReadOnlyCollection<string> GetStates();
         IReadOnlyCollection<FormInfo> GetFormsForState(string state);
+
+        /// <summary>The form's catalog entry, whatever input shape it takes; null when unknown.</summary>
+        IWorksheetForm? GetForm(string state, string form);
+
+        /// <summary>The form as a classic two-parents-plus-child-count calculator; null when unknown or when the form takes richer inputs (Oregon).</summary>
         IChildSupportCalculator? GetCalculator(string state, string form);
     }
 }

--- a/src/FairShare.Domain/Interfaces/IWorksheetForm.cs
+++ b/src/FairShare.Domain/Interfaces/IWorksheetForm.cs
@@ -1,0 +1,26 @@
+namespace FairShare.Domain.Interfaces
+{
+    /// <summary>
+    /// The catalog-facing identity of one state worksheet form. Every form implements this;
+    /// Alabama-style forms additionally implement <see cref="IChildSupportCalculator"/>, while
+    /// Oregon's worksheet takes its own richer input and is dispatched by concrete type - the
+    /// catalog lists both kinds side by side.
+    /// </summary>
+    public interface IWorksheetForm
+    {
+        /// <summary>The two-letter abbreviation for the state this form belongs to.</summary>
+        string State { get; }
+
+        /// <summary>The form key used in routes and requests, e.g. "CS42" or "Worksheet".</summary>
+        string Form { get; }
+
+        /// <summary>Human-readable form name including its revision, e.g. "CS-42 (Rev. 5/2022)".</summary>
+        string DisplayName { get; }
+
+        /// <summary>One-line description of when the form applies, e.g. "Standard custody".</summary>
+        string Description { get; }
+
+        /// <summary>Whether this form implements a shared-custody guideline variant.</summary>
+        bool IsSharedCustody { get; }
+    }
+}

--- a/src/FairShare.Domain/Services/StateGuidelineCatalog.cs
+++ b/src/FairShare.Domain/Services/StateGuidelineCatalog.cs
@@ -10,20 +10,20 @@ namespace FairShare.Domain.Services
 {
     public class StateGuidelineCatalog : IStateGuidelineCatalog
     {
-        private readonly Dictionary<string, List<IChildSupportCalculator>> _byState =
+        private readonly Dictionary<string, List<IWorksheetForm>> _byState =
             new(StringComparer.OrdinalIgnoreCase);
 
-        public StateGuidelineCatalog(IEnumerable<IChildSupportCalculator> calculators)
+        public StateGuidelineCatalog(IEnumerable<IWorksheetForm> forms)
         {
-            foreach (IChildSupportCalculator calc in calculators)
+            foreach (IWorksheetForm form in forms)
             {
-                if (!_byState.TryGetValue(calc.State, out List<IChildSupportCalculator>? list))
+                if (!_byState.TryGetValue(form.State, out List<IWorksheetForm>? list))
                 {
-                    list = new List<IChildSupportCalculator>();
-                    _byState[calc.State] = list;
+                    list = new List<IWorksheetForm>();
+                    _byState[form.State] = list;
                 }
 
-                list.Add(calc);
+                list.Add(form);
             }
         }
 
@@ -34,16 +34,19 @@ namespace FairShare.Domain.Services
 
         // Ordered by form key so the first entry is stable (the SPA lands on it when no form is given).
         public IReadOnlyCollection<FormInfo> GetFormsForState(string state)
-            => _byState.TryGetValue(state, out List<IChildSupportCalculator>? list)
+            => _byState.TryGetValue(state, out List<IWorksheetForm>? list)
                 ? list
-                    .OrderBy(c => c.Form, StringComparer.Ordinal)
-                    .Select(c => new FormInfo(c.Form, c.DisplayName, c.Description, c.IsSharedCustody))
+                    .OrderBy(f => f.Form, StringComparer.Ordinal)
+                    .Select(f => new FormInfo(f.Form, f.DisplayName, f.Description, f.IsSharedCustody))
                     .ToArray()
                 : Array.Empty<FormInfo>();
 
-        public IChildSupportCalculator? GetCalculator(string state, string form)
-            => _byState.TryGetValue(state, out List<IChildSupportCalculator>? list)
-                ? list.FirstOrDefault(c => c.Form.Equals(form, StringComparison.OrdinalIgnoreCase))
+        public IWorksheetForm? GetForm(string state, string form)
+            => _byState.TryGetValue(state, out List<IWorksheetForm>? list)
+                ? list.FirstOrDefault(f => f.Form.Equals(form, StringComparison.OrdinalIgnoreCase))
                 : null;
+
+        public IChildSupportCalculator? GetCalculator(string state, string form)
+            => GetForm(state, form) as IChildSupportCalculator;
     }
 }

--- a/src/FairShare.Tests/Api/OregonCalculationsEndpointsTests.cs
+++ b/src/FairShare.Tests/Api/OregonCalculationsEndpointsTests.cs
@@ -1,0 +1,149 @@
+using FairShare.Contracts.Auth;
+using FairShare.Contracts.Calculation;
+using FairShare.Contracts.Catalog;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class OregonCalculationsEndpointsTests : IClassFixture<FairShareApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public OregonCalculationsEndpointsTests(FairShareApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+
+    // The "sole-custody-payer-premium" golden case (or-worksheet-golden.json): values read back
+    // from the official DOJ workbook - plaintiff pays $506 total for the two minors.
+    private static CalculationRequest GoldenCaseRequest() => new()
+    {
+        Oregon = new OregonCalculationRequest
+        {
+            Plaintiff = new OregonParentDto { MonthlyIncome = 4500, ChildrensHealthCoverageCost = 250, AverageOvernights = 91 },
+            Defendant = new OregonParentDto { MonthlyIncome = 3200, AverageOvernights = 274 },
+            JointMinorChildren = 2,
+            CashMedical = "No",
+            CoverageSelection = "Plaintiff"
+        }
+    };
+
+    [Fact]
+    public async Task PostCalculation_OregonWorksheet_ReturnsLinesPayerAndExtras()
+    {
+        string accessToken = await LoginAsAdminAsync();
+
+        HttpResponseMessage response = await SendAuthorizedAsync(HttpMethod.Post,
+            "api/v1/states/OR/forms/Worksheet/calculations", accessToken, GoldenCaseRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        CalculationResponse body = (await response.Content.ReadFromJsonAsync<CalculationResponse>())!;
+
+        Assert.True(body.Success);
+        Assert.Equal("OR", body.State);
+        Assert.Equal("Worksheet", body.Form);
+        Assert.Equal(2, body.NumberOfChildren);
+        Assert.Equal("Plaintiff", body.Payer);
+        Assert.Equal(506, body.FinalAmount);
+
+        Assert.NotNull(body.Oregon);
+        Assert.Equal(506, body.Oregon!.PlaintiffTotalSupport);
+        Assert.Equal(0, body.Oregon.DefendantTotalSupport);
+        Assert.Equal("Plaintiff", body.Oregon.PaysForMinorChildren);
+        Assert.Equal("Plaintiff", body.Oregon.CoverageProvider);
+        Assert.Equal("2026-07-01", body.Oregon.RuleEffectiveDate);
+
+        Assert.Equal("Percent", body.Lines.Single(l => l.Number == "1i").Format);
+        Assert.Equal("Number", body.Lines.Single(l => l.Number == "1d").Format);
+        Assert.Equal(506, body.Lines.Single(l => l.Number == "9e").Plaintiff);
+    }
+
+    [Fact]
+    public async Task PostCalculation_Oregon_WithoutOregonInputs_ReturnsBadRequest()
+    {
+        string accessToken = await LoginAsAdminAsync();
+
+        HttpResponseMessage response = await SendAuthorizedAsync(HttpMethod.Post,
+            "api/v1/states/OR/forms/Worksheet/calculations", accessToken, new CalculationRequest());
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostCalculation_Oregon_BadCashMedicalValue_ReturnsBadRequest()
+    {
+        string accessToken = await LoginAsAdminAsync();
+
+        CalculationRequest request = GoldenCaseRequest();
+        request.Oregon!.CashMedical = "maybe";
+
+        HttpResponseMessage response = await SendAuthorizedAsync(HttpMethod.Post,
+            "api/v1/states/OR/forms/Worksheet/calculations", accessToken, request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetStates_ListsOregon()
+    {
+        HttpResponseMessage response = await _client.GetAsync("api/v1/states");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        List<StateSummaryDto> states = (await response.Content.ReadFromJsonAsync<List<StateSummaryDto>>())!;
+
+        Assert.Contains(states, s => s.State == "OR");
+    }
+
+    [Fact]
+    public async Task GetForms_Oregon_ListsTheWorksheet()
+    {
+        HttpResponseMessage response = await _client.GetAsync("api/v1/states/OR/forms");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        List<FormSummaryDto> forms = (await response.Content.ReadFromJsonAsync<List<FormSummaryDto>>())!;
+
+        FormSummaryDto worksheet = Assert.Single(forms);
+        Assert.Equal("Worksheet", worksheet.Form);
+        Assert.Equal("Child Support Worksheet (CSF 02 0910)", worksheet.DisplayName);
+        Assert.False(worksheet.IsSharedCustody);
+    }
+
+    [Fact]
+    public async Task ExportXlsx_Oregon_ReturnsNotFound()
+    {
+        string accessToken = await LoginAsAdminAsync();
+
+        HttpResponseMessage response = await SendAuthorizedAsync(HttpMethod.Post,
+            "api/v1/states/OR/forms/Worksheet/calculations/export/xlsx", accessToken, GoldenCaseRequest());
+
+        // No Oregon export template yet - the endpoint must say so rather than produce a wrong file.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task<string> LoginAsAdminAsync()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = "admin",
+            Password = "Adm!n-Test-12345"
+        });
+
+        AuthTokenResponse tokens = (await response.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+        return tokens.AccessToken;
+    }
+
+    private async Task<HttpResponseMessage> SendAuthorizedAsync(HttpMethod method, string url, string accessToken, object body)
+    {
+        using HttpRequestMessage request = new(method, url)
+        {
+            Content = JsonContent.Create(body)
+        };
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+
+        return await _client.SendAsync(request);
+    }
+}


### PR DESCRIPTION
Part of #128 · Builds on #136 (the engine)

Oregon becomes a first-class catalog entry and API surface:

- **`IWorksheetForm`** — the catalog-facing identity (State/Form/DisplayName/Description/IsSharedCustody). `IChildSupportCalculator` extends it; `OregonWorksheetCalculator` implements it directly (`OR`/`Worksheet`), since its input shape is richer than two-parents-plus-child-count.
- **Catalog** stores forms, `GetCalculator` narrows to the classic interface, new `GetForm` returns any entry. DI registers all three forms as `IWorksheetForm` — the add-a-state recipe stays one line per form.
- **Contracts (additive)**: `CalculationRequest.oregon` block (per-parent Oregon fields + case-level: joint minors/CAS, cash-medical election, coverage selection, higher-amount flag) and `CalculationResponse.oregon` extras (both parents' line-9e totals, pays-for-minors, coverage provider, reasonable-cost total, rule effective date). Alabama clients see no change.
- **Controller** dispatches by form shape; missing oregon block or invalid enum text → 400; Oregon export → 404 until the template slice lands.

`GET /states` now lists `OR`; `GET /states/OR/forms` lists the Worksheet. **299 tests green** — 6 new API tests pinned to the golden-fixture values (the $506 sole-custody case travels the whole HTTP stack), all Alabama tests untouched.

Note: the Oregon *page* still renders the Alabama-shaped inputs until #129 — visible on the test stack only; prod deploys stay pinned until the UI slice ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)