### PR TITLE
feat: Oregon worksheet page - state-specific input form, dual-payer results, beta badge

### DIFF
--- a/src/FairShare.Web/Components/OregonParentCard.razor
+++ b/src/FairShare.Web/Components/OregonParentCard.razor
@@ -1,0 +1,160 @@
+@using FairShare.Contracts.Calculation
+
+@* One parent's column of the Oregon worksheet (CSF 02 0910). Oregon's inputs are richer than the
+   classic ParentCard's five figures and carry cents, so this card is its own component; saved-parent
+   profiles are Alabama-shaped and deliberately absent here until profiles learn Oregon fields. *@
+<div class="col-12 col-lg-6">
+    <div class="card h-100 shadow-sm fs-party-card @PartyClass">
+        <div class="card-header text-center d-flex flex-column gap-2">
+            <div class="d-flex justify-content-between align-items-center">
+                <span class="badge fs-party-badge">@Title</span>
+                <button type="button" class="btn btn-outline-secondary btn-sm"
+                        @onclick="ClearData"
+                        title="Clear this parent's values">
+                    Clear
+                </button>
+            </div>
+        </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_Income")">Monthly income</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_Income")" @bind="Data.MonthlyIncome" class="form-control"
+                           aria-describedby="@($"{Prefix}_IncomeHelp")" />
+                </div>
+                <div id="@($"{Prefix}_IncomeHelp")" class="form-text">
+                    Gross monthly income - actual, potential, or presumed (worksheet line 1a).
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_SpousalIn")">Spousal support owed to this parent</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_SpousalIn")" @bind="Data.SpousalSupportReceived" class="form-control" />
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_SpousalOut")">Spousal support this parent owes</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_SpousalOut")" @bind="Data.SpousalSupportPaid" class="form-control" />
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_Dues")">Mandatory union dues</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_Dues")" @bind="Data.UnionDues" class="form-control" />
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_OwnHealth")">Cost of this parent's own health insurance</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_OwnHealth")" @bind="Data.OwnHealthInsuranceCost" class="form-control" />
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_NonJoint")">Non-joint children</label>
+                <input type="number" min="0" max="20" id="@($"{Prefix}_NonJoint")" @bind="Data.NonJointChildren" class="form-control"
+                       aria-describedby="@($"{Prefix}_NonJointHelp")" />
+                <div id="@($"{Prefix}_NonJointHelp")" class="form-text">
+                    This parent's other legal children - minors in the household or under an ongoing support order (line 1c).
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_ChildCare")">Child care costs this parent pays</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_ChildCare")" @bind="Data.ChildCareCosts" class="form-control"
+                           aria-describedby="@($"{Prefix}_ChildCareHelp")" />
+                </div>
+                <div id="@($"{Prefix}_ChildCareHelp")" class="form-text">
+                    For joint children under 13 (or disabled), work- or training-related, out of pocket (line 3a).
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="@($"{Prefix}_NoCoverage")" @bind="NoCoverage" />
+                    <label class="form-check-label" for="@($"{Prefix}_NoCoverage")">No appropriate health coverage available to this parent</label>
+                </div>
+                @if (!NoCoverage)
+                {
+                    <label class="form-label mt-2" for="@($"{Prefix}_Premium")">Cost to enroll the joint children in this parent's coverage</label>
+                    <div class="input-group">
+                        <span class="input-group-text">$</span>
+                        <input type="number" step="0.01" min="0" id="@($"{Prefix}_Premium")" @bind="PremiumValue" class="form-control"
+                               aria-describedby="@($"{Prefix}_PremiumHelp")" />
+                    </div>
+                    <div id="@($"{Prefix}_PremiumHelp")" class="form-text">
+                        The children's share of the premium only; $0 means coverage is available at no cost (line 4a).
+                    </div>
+                }
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_Overnights")">Average overnights per year</label>
+                <input type="number" step="0.5" min="0" max="365" id="@($"{Prefix}_Overnights")" @bind="Data.AverageOvernights" class="form-control"
+                       aria-describedby="@($"{Prefix}_OvernightsHelp")" />
+                <div id="@($"{Prefix}_OvernightsHelp")" class="form-text">
+                    Two-year average of overnights with the joint minor children; both parents must total 365 (line 6a).
+                </div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="@($"{Prefix}_Ssva")">Social Security / veterans benefits paid to the children</label>
+                <div class="input-group">
+                    <span class="input-group-text">$</span>
+                    <input type="number" step="0.01" min="0" id="@($"{Prefix}_Ssva")" @bind="Data.SocialSecurityVeteransBenefits" class="form-control"
+                           aria-describedby="@($"{Prefix}_SsvaHelp")" />
+                </div>
+                <div id="@($"{Prefix}_SsvaHelp")" class="form-text">
+                    Benefits paid to the joint children because of this parent's disability or retirement (line 8e).
+                </div>
+            </div>
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="@($"{Prefix}_MinException")" @bind="Data.MinimumOrderException" />
+                <label class="form-check-label" for="@($"{Prefix}_MinException")">Exception to the $100 minimum order</label>
+                <div class="form-text">
+                    E.g. incarceration or disability benefits as the sole income (OAR 137-050-0755).
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string Title { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string Prefix { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public OregonParentDto Data { get; set; } = new();
+
+    private string PartyClass => $"fs-party-{Prefix.ToLowerInvariant()}";
+
+    // Line 4a's "none": a null premium means no appropriate coverage is available. The checkbox
+    // owns the null; unchecking restores an editable $0 premium.
+    private bool NoCoverage
+    {
+        get => Data.ChildrensHealthCoverageCost is null;
+        set => Data.ChildrensHealthCoverageCost = value ? null : Data.ChildrensHealthCoverageCost ?? 0m;
+    }
+
+    private decimal PremiumValue
+    {
+        get => Data.ChildrensHealthCoverageCost ?? 0m;
+        set => Data.ChildrensHealthCoverageCost = value;
+    }
+
+    private void ClearData()
+    {
+        Data.MonthlyIncome = 0;
+        Data.SpousalSupportReceived = 0;
+        Data.SpousalSupportPaid = 0;
+        Data.UnionDues = 0;
+        Data.OwnHealthInsuranceCost = 0;
+        Data.NonJointChildren = 0;
+        Data.ChildCareCosts = 0;
+        Data.ChildrensHealthCoverageCost = null;
+        Data.AverageOvernights = 0;
+        Data.SocialSecurityVeteransBenefits = 0;
+        Data.MinimumOrderException = false;
+    }
+}

--- a/src/FairShare.Web/Components/OregonWorksheet.razor
+++ b/src/FairShare.Web/Components/OregonWorksheet.razor
@@ -249,6 +249,8 @@
 
             if (!response.IsSuccessStatusCode)
             {
+                // Same rule as the validation stops: no stale answer sits under an error message.
+                ClearResult();
                 errors.Add(response.StatusCode switch
                 {
                     System.Net.HttpStatusCode.NotFound => "No calculator is registered for this state and form.",
@@ -306,6 +308,9 @@
         submitted
         || jointMinorChildren != 1
         || jointChildrenAttendingSchool != 0
+        || cashMedical != "No"
+        || !string.IsNullOrEmpty(coverageSelection)
+        || orderCoverageAtHigherAmount
         || HasFigures(plaintiff)
         || HasFigures(defendant);
 

--- a/src/FairShare.Web/Components/OregonWorksheet.razor
+++ b/src/FairShare.Web/Components/OregonWorksheet.razor
@@ -1,0 +1,393 @@
+@using FairShare.Contracts.Calculation
+@inject HttpClient Http
+@inject IJSRuntime JS
+
+@* Oregon's Child Support Worksheet (CSF 02 0910) - its own input surface because Oregon's inputs
+   (spousal support both directions, overnights, Children Attending School, medical elections) do
+   not fit the classic two-parents-plus-child-count shape. Calculator.razor hands off to this
+   component for the OR state. *@
+
+<div class="alert alert-warning py-2 small text-center" role="status">
+    <strong>Beta</strong> - the Oregon worksheet matches the state's official calculator in our
+    tests, but has not yet been validated against real Oregon cases. Please compare results with
+    the <a href="https://justice.oregon.gov/guidelines/" target="_blank" rel="noopener">official Oregon calculator</a>.
+</div>
+
+<div class="row g-3 mb-2 justify-content-center">
+    <div class="col-12 col-sm-6 col-lg-3 text-center">
+        <label class="form-label" for="OR_JointMinors">Joint minor children</label>
+        <select id="OR_JointMinors" @bind="jointMinorChildren" class="form-select" aria-describedby="OR_JointMinorsHelp">
+            @for (int n = 0; n <= 10; n++)
+            {
+                <option value="@n">@n</option>
+            }
+        </select>
+        <div id="OR_JointMinorsHelp" class="form-text">
+            Include 18-year-olds attending high school and living with a parent (line 1d).
+        </div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3 text-center">
+        <label class="form-label" for="OR_JointCas">Children Attending School (18-20)</label>
+        <select id="OR_JointCas" @bind="jointChildrenAttendingSchool" class="form-select" aria-describedby="OR_JointCasHelp">
+            @for (int n = 0; n <= 10; n++)
+            {
+                <option value="@n">@n</option>
+            }
+        </select>
+        <div id="OR_JointCasHelp" class="form-text">
+            Unmarried 18-to-20-year-olds in school at least half time; Oregon support runs to 21 and
+            is paid directly to them (line 1e).
+        </div>
+    </div>
+</div>
+
+<div class="row g-3 mb-4 justify-content-center">
+    <div class="col-12 col-sm-6 col-lg-3 text-center">
+        <label class="form-label" for="OR_CashMedical">Cash medical support</label>
+        <select id="OR_CashMedical" @bind="cashMedical" class="form-select" aria-describedby="OR_CashMedicalHelp">
+            <option value="No">No - coverage is available (or the order explains why not)</option>
+            <option value="Yes">Yes - no appropriate coverage is available</option>
+            <option value="Contingent">Contingent - owed whenever coverage is not provided</option>
+        </select>
+        <div id="OR_CashMedicalHelp" class="form-text">Worksheet line 5a (OAR 137-050-0750).</div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3 text-center">
+        <label class="form-label" for="OR_Coverage">Who provides health coverage?</label>
+        <select id="OR_Coverage" @bind="coverageSelection" class="form-select" aria-describedby="OR_CoverageHelp">
+            <option value="">Choose for me (per the rule)</option>
+            <option value="Plaintiff">Plaintiff</option>
+            <option value="Defendant">Defendant</option>
+            <option value="Both">Both parents</option>
+            <option value="EitherWhenAvailable">Either parent, when available</option>
+        </select>
+        <div id="OR_CoverageHelp" class="form-text">
+            Line 4f. "Choose for me" applies OAR 137-050-0750: the qualifying parent, or with both
+            qualifying, the parent with more parenting time.
+        </div>
+        <div class="form-check mt-2 text-start">
+            <input type="checkbox" class="form-check-input" id="OR_HigherAmount" @bind="orderCoverageAtHigherAmount" />
+            <label class="form-check-label small" for="OR_HigherAmount">
+                Order coverage even above the reasonable-cost amount (line 4e)
+            </label>
+        </div>
+    </div>
+</div>
+
+@if (jointMinorChildren > 0)
+{
+    <div class="text-center small mb-3 @(OvernightsTotal == 365 ? "text-muted" : "text-danger")">
+        Overnights entered: @OvernightsTotal.ToString("0.##") of 365
+    </div>
+}
+
+<div class="row g-4">
+    <OregonParentCard Title="Plaintiff" Prefix="Plaintiff" Data="plaintiff" />
+    <OregonParentCard Title="Defendant" Prefix="Defendant" Data="defendant" />
+</div>
+
+<div class="mt-3 d-flex gap-2">
+    <button class="btn btn-primary" @onclick="CalculateAsync" disabled="@calculating">Calculate</button>
+    <button class="btn btn-outline-danger" @onclick="ResetAsync">Reset</button>
+</div>
+
+@if (errors.Any())
+{
+    <div class="mt-3" role="alert">
+        <ul class="text-danger">
+            @foreach (var error in errors)
+            {
+                <li>@error</li>
+            }
+        </ul>
+    </div>
+}
+
+<div class="mt-5">
+    <div class="card shadow-sm fs-results-card">
+        <div class="card-header text-center"><strong>Results</strong></div>
+        <div class="card-body" aria-live="polite">
+            @if (submitted && result is not null && result.Success)
+            {
+                <p class="fw-bold text-center mb-0">@ResultSentence()</p>
+
+                @if (result.Oregon is { } extras)
+                {
+                    <p class="text-center text-muted small mb-0 mt-1">
+                        Health care coverage: @ProviderText(extras.CoverageProvider)
+                        (reasonable cost cap $@extras.ReasonableCostTotal.ToString("N0")/month).
+                    </p>
+                }
+
+                @if (result.Lines.Any())
+                {
+                    <div class="table-responsive mt-3">
+                        <table class="table table-sm table-striped mb-0 worksheet-table">
+                            <caption class="visually-hidden">Oregon Child Support Worksheet lines</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Line</th>
+                                    <th scope="col">Item</th>
+                                    <th scope="col" class="text-end">Plaintiff</th>
+                                    <th scope="col" class="text-end">Defendant</th>
+                                    <th scope="col" class="text-end">Combined</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var line in result.Lines)
+                                {
+                                    <tr class="@(line.Number == "9e" ? "fs-row-recommended-order fw-bold" : "")">
+                                        <th scope="row" class="fw-normal text-start">@line.Number</th>
+                                        <td>@line.Label</td>
+                                        <td class="text-end">@FormatCell(line, line.Plaintiff)</td>
+                                        <td class="text-end">@FormatCell(line, line.Defendant)</td>
+                                        <td class="text-end">@FormatCell(line, line.Combined)</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                }
+            }
+            else if (submitted && result is not null && !result.Success)
+            {
+                <ul class="text-danger mb-0">
+                    @foreach (var e in result.Errors)
+                    {
+                        <li>@e.Code: @e.Message</li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <p class="text-muted mb-0">Enter inputs and Calculate.</p>
+            }
+        </div>
+    </div>
+    <p class="text-muted small text-center mt-2 mb-0">
+        Implements OAR 137-050 effective @(result?.Oregon?.RuleEffectiveDate ?? "2026-07-01") -
+        compare with the <a href="https://justice.oregon.gov/guidelines/" target="_blank" rel="noopener">official Oregon calculator</a>.
+        FairShare provides estimates for informational purposes only - not legal advice.
+        Actual support obligations are determined by the court under your state's guidelines.
+        See the <a href="/terms">terms</a>.
+    </p>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string State { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string Form { get; set; } = string.Empty;
+
+    private readonly OregonParentDto plaintiff = new();
+    private readonly OregonParentDto defendant = new();
+    private int jointMinorChildren = 1;
+    private int jointChildrenAttendingSchool;
+    private string cashMedical = "No";
+    private string coverageSelection = string.Empty;
+    private bool orderCoverageAtHigherAmount;
+
+    private CalculationResponse? result;
+    private bool submitted;
+    private bool calculating;
+    private readonly List<string> errors = new();
+
+    private const string ApiUnreachableMessage = "The FairShare API could not be reached. Check your connection and try again.";
+
+    private decimal OvernightsTotal => plaintiff.AverageOvernights + defendant.AverageOvernights;
+
+    private async Task CalculateAsync()
+    {
+        if (calculating)
+        {
+            return;
+        }
+
+        errors.Clear();
+
+        if (jointMinorChildren + jointChildrenAttendingSchool < 1)
+        {
+            ClearResult();
+            errors.Add("Enter at least one joint child (minor or Child Attending School).");
+            return;
+        }
+
+        if (jointMinorChildren > 0 && OvernightsTotal != 365m)
+        {
+            ClearResult();
+            errors.Add("The parents' average overnights must total 365.");
+            return;
+        }
+
+        calculating = true;
+
+        try
+        {
+            var request = new CalculationRequest
+            {
+                Oregon = new OregonCalculationRequest
+                {
+                    Plaintiff = plaintiff,
+                    Defendant = defendant,
+                    JointMinorChildren = jointMinorChildren,
+                    JointChildrenAttendingSchool = jointChildrenAttendingSchool,
+                    CashMedical = cashMedical,
+                    CoverageSelection = string.IsNullOrEmpty(coverageSelection) ? null : coverageSelection,
+                    OrderCoverageAtHigherAmount = orderCoverageAtHigherAmount
+                }
+            };
+
+            HttpResponseMessage response;
+
+            try
+            {
+                response = await Http.PostAsJsonAsync($"api/v1/states/{State}/forms/{Form}/calculations", request);
+            }
+            catch (HttpRequestException)
+            {
+                ClearResult();
+                errors.Add(ApiUnreachableMessage);
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                errors.Add(response.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.NotFound => "No calculator is registered for this state and form.",
+                    System.Net.HttpStatusCode.BadRequest => "The submitted inputs were invalid. Check the values and try again.",
+                    System.Net.HttpStatusCode.Unauthorized => "Your session has expired. Please log in again.",
+                    System.Net.HttpStatusCode.Forbidden => "You are not authorized to perform this calculation.",
+                    _ => $"Calculation request failed ({(int)response.StatusCode})."
+                });
+                return;
+            }
+
+            result = await response.Content.ReadFromJsonAsync<CalculationResponse>();
+            submitted = true;
+        }
+        finally
+        {
+            calculating = false;
+        }
+    }
+
+    private async Task ResetAsync()
+    {
+        if (HasEnteredData && !await JS.InvokeAsync<bool>("confirm", "Clear all entered figures and results?"))
+        {
+            return;
+        }
+
+        ClearParent(plaintiff);
+        ClearParent(defendant);
+        jointMinorChildren = 1;
+        jointChildrenAttendingSchool = 0;
+        cashMedical = "No";
+        coverageSelection = string.Empty;
+        orderCoverageAtHigherAmount = false;
+        ClearResult();
+        errors.Clear();
+    }
+
+    private static void ClearParent(OregonParentDto parent)
+    {
+        parent.MonthlyIncome = 0;
+        parent.SpousalSupportReceived = 0;
+        parent.SpousalSupportPaid = 0;
+        parent.UnionDues = 0;
+        parent.OwnHealthInsuranceCost = 0;
+        parent.NonJointChildren = 0;
+        parent.ChildCareCosts = 0;
+        parent.ChildrensHealthCoverageCost = null;
+        parent.AverageOvernights = 0;
+        parent.SocialSecurityVeteransBenefits = 0;
+        parent.MinimumOrderException = false;
+    }
+
+    private bool HasEnteredData =>
+        submitted
+        || jointMinorChildren != 1
+        || jointChildrenAttendingSchool != 0
+        || HasFigures(plaintiff)
+        || HasFigures(defendant);
+
+    private static bool HasFigures(OregonParentDto parent) =>
+        parent.MonthlyIncome != 0
+        || parent.SpousalSupportReceived != 0
+        || parent.SpousalSupportPaid != 0
+        || parent.UnionDues != 0
+        || parent.OwnHealthInsuranceCost != 0
+        || parent.NonJointChildren != 0
+        || parent.ChildCareCosts != 0
+        || parent.ChildrensHealthCoverageCost is not null
+        || parent.AverageOvernights != 0
+        || parent.SocialSecurityVeteransBenefits != 0
+        || parent.MinimumOrderException;
+
+    private void ClearResult()
+    {
+        result = null;
+        submitted = false;
+    }
+
+    // Oregon can obligate both parents at once: Children Attending School are paid directly by
+    // each parent, so the sentence covers one payer, both, or neither.
+    private string ResultSentence()
+    {
+        if (result?.Oregon is not { } extras)
+        {
+            return string.Empty;
+        }
+
+        bool plaintiffOwes = extras.PlaintiffTotalSupport > 0;
+        bool defendantOwes = extras.DefendantTotalSupport > 0;
+
+        if (extras.PaysForMinorChildren is { } payer)
+        {
+            decimal payerTotal = payer == "Plaintiff" ? extras.PlaintiffTotalSupport : extras.DefendantTotalSupport;
+            string other = payer == "Plaintiff" ? "Defendant" : "Plaintiff";
+            decimal otherTotal = payer == "Plaintiff" ? extras.DefendantTotalSupport : extras.PlaintiffTotalSupport;
+
+            return otherTotal > 0
+                ? $"{payer} owes ${payerTotal:N0} per month; {other} owes ${otherTotal:N0} directly to the Children Attending School."
+                : $"{payer} owes ${payerTotal:N0} per month.";
+        }
+
+        if (plaintiffOwes || defendantOwes)
+        {
+            return $"Both parents owe support directly to the Children Attending School: Plaintiff ${extras.PlaintiffTotalSupport:N0}, Defendant ${extras.DefendantTotalSupport:N0} per month.";
+        }
+
+        return "No net transfer.";
+    }
+
+    private static string ProviderText(string provider) => provider switch
+    {
+        "Plaintiff" => "provided by the Plaintiff",
+        "Defendant" => "provided by the Defendant",
+        "Both" => "provided by both parents",
+        _ => "either parent, when coverage becomes available",
+    };
+
+    // Oregon computes to the penny and its percentages carry four decimals, so cells show cents
+    // and 2-decimal percents; counts (children, overnights) show as plain numbers.
+    private static string FormatCell(WorksheetLineDto line, decimal? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        if (string.Equals(line.Format, "Percent", StringComparison.OrdinalIgnoreCase))
+        {
+            return value.Value.ToString("P2");
+        }
+
+        if (string.Equals(line.Format, "Number", StringComparison.OrdinalIgnoreCase))
+        {
+            return value.Value.ToString("0.##");
+        }
+
+        return value.Value < 0
+            ? $"-${Math.Abs(value.Value):N2}"
+            : $"${value.Value:N2}";
+    }
+}

--- a/src/FairShare.Web/Pages/Calculator.razor
+++ b/src/FairShare.Web/Pages/Calculator.razor
@@ -45,6 +45,14 @@
         }
     }
 
+    @if (IsOregonState)
+    {
+        @* Oregon's inputs don't fit the classic two-parents-plus-child-count surface below; the
+           state's whole form lives in its own component. *@
+        <OregonWorksheet State="@State" Form="@(Form ?? string.Empty)" />
+    }
+    else
+    {
     <div class="row g-3 mb-4 justify-content-center">
         <div class="col-12 col-sm-5 col-lg-3 text-center">
             <label class="form-label" for="NumberOfChildren">Number of Children</label>
@@ -203,6 +211,7 @@
             guidelines. See the <a href="/terms">terms</a>.
         </p>
     </div>
+    }
 
     <div class="mt-4">
         <a href="/" class="btn btn-link">&larr; Back to States</a>
@@ -235,6 +244,7 @@
     private List<FormSummaryDto>? forms;
     private string? formsLoadedForState;
     private string? activeForm;
+    private string? activeState;
 
     private const string ApiUnreachableMessage = "The FairShare API could not be reached. Check your connection and try again.";
     private const string StaleClientMessage = "Your browser is running an older version of FairShare - reload the page (Ctrl+F5) and try again.";
@@ -249,6 +259,9 @@
     // hardcoded form name — shared UI carries no state or form specifics (ADR 0005).
     private bool RequiresPrimaryCustody =>
         CurrentForm is { } current && !current.IsSharedCustody;
+
+    // The one place the shared page names a state: routing to that state's own input component.
+    private bool IsOregonState => State.Equals("OR", StringComparison.OrdinalIgnoreCase);
 
     protected override async Task OnInitializedAsync()
     {
@@ -377,8 +390,20 @@
             return;
         }
 
+        bool stateChanged = activeState is not null && !string.Equals(activeState, State, StringComparison.OrdinalIgnoreCase);
+        activeState = State;
+
         bool switched = activeForm is not null && !string.Equals(activeForm, Form, StringComparison.OrdinalIgnoreCase);
         activeForm = Form;
+
+        if (stateChanged)
+        {
+            // A different state means a different input shape - never carry one state's result
+            // (or fire its request) across; the new state starts clean.
+            errors.Clear();
+            ClearResult();
+            return;
+        }
 
         if (switched)
         {


### PR DESCRIPTION
Part of #129 · The user-facing half of the Oregon expansion (engine/wiring/oracle: #136–#138).

- **`Calculator.razor`** hands the `OR` state to its own component — the one place the shared page names a state, because a per-state input form *is* state-specific UI. A state switch now clears results instead of firing the previous state's request shape at the new endpoint.
- **`OregonParentCard`** — one parent's column of CSF 02 0910: income, spousal support both directions, union dues, own health insurance, non-joint children, child care, the children's premium with a "no appropriate coverage available" checkbox (line 4a's "none" as null), overnights, SS/VA benefits, and the minimum-order exception. Inline help cites worksheet lines.
- **`OregonWorksheet`** — joint minors + Children Attending School (0–10 selects), cash-medical election, coverage-provider select defaulting to "Choose for me (per the rule)" (the OAR 137-050-0750 auto-selection), the line-4e higher-amount flag, a live overnights-of-365 indicator, and results that handle Oregon's dual-payer reality: one payer, *both parents paying Children Attending School directly*, or no transfer. Cent-precision table (2-dp currency and percents, plain counts), line 9e highlighted as the order row.
- **Beta badge** (per the design session: stays until the real-case validation passes) and the legal-posture line on every estimate: "Implements OAR 137-050 effective 2026-07-01" + link to the official Oregon calculator.

Deliberately absent (named in-code): saved-parent picker (profiles are Alabama-shaped), guest-work stash, export (endpoint 404s), and the **overnights pattern-builder + explainer page — the next slice of #129**.

315 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)