### PR TITLE
feat: overnights pattern-builder and the Oregon worksheet guide

### DIFF
--- a/src/FairShare.Web/Components/OregonOvernightsHelper.razor
+++ b/src/FairShare.Web/Components/OregonOvernightsHelper.razor
@@ -59,7 +59,7 @@
                 </div>
                 <div class="col-12 col-md-6">
                     <label class="form-label" for="OR_Holiday">Additional overnights per year</label>
-                    <input type="number" min="-100" max="100" id="OR_Holiday" @bind="holidayAdjustment" class="form-control"
+                    <input type="number" step="0.5" min="-100" max="100" id="OR_Holiday" @bind="holidayAdjustment" class="form-control"
                            aria-describedby="OR_HolidayHelp" disabled="@(pattern == "fifty-fifty")" />
                     <div id="OR_HolidayHelp" class="form-text">
                         Holidays, school breaks, or half-day equivalents (a 4-12 hour block counts as half a day
@@ -90,7 +90,10 @@
     private string pattern = "eow";
     private bool weekendsIncludeSunday;
     private int summerOvernights;
-    private int holidayAdjustment;
+
+    // Decimal so half-day equivalents (OAR 137-050-0730: a 4-12 hour block is half a day) can be
+    // entered directly, as the field's help text promises.
+    private decimal holidayAdjustment;
 
     private decimal ComputedAverage => ComputeTwoYearAverage();
 
@@ -117,7 +120,7 @@
 
         if (pattern == "none" && summerOvernights == 0)
         {
-            return Math.Clamp(holidayAdjustment, 0, 365);
+            return Math.Clamp(holidayAdjustment, 0m, 365m);
         }
 
         int nights = 0;

--- a/src/FairShare.Web/Components/OregonOvernightsHelper.razor
+++ b/src/FairShare.Web/Components/OregonOvernightsHelper.razor
@@ -1,0 +1,189 @@
+@* "Help me count overnights" (worksheet line 6a): builds a parenting schedule from presets and
+   counts the overnights on a real simulated two-year calendar - the same two-year-average idea as
+   Oregon's parenting time calculator, without its per-date editing. The computed number is a
+   starting point the parent can always override in the card; exotic schedules belong in the
+   state's own calendar tool (linked below). *@
+
+<div class="card mb-4">
+    <div class="card-header p-0">
+        <button type="button"
+                class="btn btn-link w-100 text-start text-decoration-none px-3 py-2"
+                @onclick="() => expanded = !expanded"
+                aria-expanded="@expanded"
+                aria-controls="OR_OvernightsHelper">
+            @(expanded ? "▾" : "▸") Help me count overnights
+        </button>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body" id="OR_OvernightsHelper">
+            <div class="row g-3">
+                <div class="col-12 col-md-6">
+                    <label class="form-label" for="OR_PatternParent">Which parent has the visiting schedule?</label>
+                    <select id="OR_PatternParent" @bind="patternParent" class="form-select" aria-describedby="OR_PatternParentHelp">
+                        <option value="Plaintiff">Plaintiff</option>
+                        <option value="Defendant">Defendant</option>
+                    </select>
+                    <div id="OR_PatternParentHelp" class="form-text">
+                        The other parent gets the remaining nights (365 total).
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <label class="form-label" for="OR_Pattern">Schedule</label>
+                    <select id="OR_Pattern" @bind="pattern" class="form-select">
+                        <option value="none">No overnights</option>
+                        <option value="eow">Every other weekend</option>
+                        <option value="eow-midweek">Every other weekend + one weeknight each week</option>
+                        <option value="first-third">1st and 3rd weekends of the month</option>
+                        <option value="second-fourth">2nd and 4th weekends of the month</option>
+                        <option value="every-weekend">Every weekend</option>
+                        <option value="fifty-fifty">Equal time (2-2-3, alternating weeks, ...)</option>
+                    </select>
+                </div>
+            </div>
+            @if (pattern is not "none" and not "fifty-fifty")
+            {
+                <div class="form-check mt-2">
+                    <input type="checkbox" class="form-check-input" id="OR_SundayNight" @bind="weekendsIncludeSunday" />
+                    <label class="form-check-label" for="OR_SundayNight">Weekends include Sunday night</label>
+                </div>
+            }
+            <div class="row g-3 mt-1">
+                <div class="col-12 col-md-6">
+                    <label class="form-label" for="OR_Summer">Consecutive summer overnights</label>
+                    <input type="number" min="0" max="59" id="OR_Summer" @bind="summerOvernights" class="form-control"
+                           aria-describedby="OR_SummerHelp" disabled="@(pattern == "fifty-fifty")" />
+                    <div id="OR_SummerHelp" class="form-text">
+                        A summer block with the visiting parent (starting July 1), like the state tool's 4-59 summer nights.
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <label class="form-label" for="OR_Holiday">Additional overnights per year</label>
+                    <input type="number" min="-100" max="100" id="OR_Holiday" @bind="holidayAdjustment" class="form-control"
+                           aria-describedby="OR_HolidayHelp" disabled="@(pattern == "fifty-fifty")" />
+                    <div id="OR_HolidayHelp" class="form-text">
+                        Holidays, school breaks, or half-day equivalents (a 4-12 hour block counts as half a day
+                        under OAR 137-050-0730). Use a negative number for nights the schedule loses.
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex align-items-center gap-3 mt-3 flex-wrap">
+                <button type="button" class="btn btn-outline-primary" @onclick="Apply">
+                    Use @ComputedAverage.ToString("0.##") overnights
+                </button>
+                <span class="text-muted small">
+                    Counted on a simulated two-year calendar and averaged, the way Oregon's own
+                    <a href="https://justice.oregon.gov/calculator/parenting_time/" target="_blank" rel="noopener">parenting time calculator</a>
+                    works; use that tool for schedules these presets can't express, then type its number into the cards.
+                </span>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    /// <summary>Called with (plaintiffOvernights, defendantOvernights) when the parent applies the computed number.</summary>
+    [Parameter, EditorRequired] public EventCallback<(decimal Plaintiff, decimal Defendant)> OnApply { get; set; }
+
+    private bool expanded;
+    private string patternParent = "Defendant";
+    private string pattern = "eow";
+    private bool weekendsIncludeSunday;
+    private int summerOvernights;
+    private int holidayAdjustment;
+
+    private decimal ComputedAverage => ComputeTwoYearAverage();
+
+    private async Task Apply()
+    {
+        decimal visiting = Math.Clamp(ComputedAverage, 0m, 365m);
+        decimal remaining = 365m - visiting;
+
+        (decimal p, decimal d) = patternParent == "Plaintiff" ? (visiting, remaining) : (remaining, visiting);
+        await OnApply.InvokeAsync((p, d));
+    }
+
+    /// <summary>
+    /// Counts the visiting parent's overnights over 2026-2027 (730 nights) and averages. The
+    /// summer block simply grants the visiting parent every night in its window, so pattern
+    /// nights inside the block are never double counted.
+    /// </summary>
+    private decimal ComputeTwoYearAverage()
+    {
+        if (pattern == "fifty-fifty")
+        {
+            return 182.5m;
+        }
+
+        if (pattern == "none" && summerOvernights == 0)
+        {
+            return Math.Clamp(holidayAdjustment, 0, 365);
+        }
+
+        int nights = 0;
+        DateOnly start = new(2026, 1, 1);
+
+        for (int offset = 0; offset < 730; offset++)
+        {
+            DateOnly date = start.AddDays(offset);
+
+            if (InSummerBlock(date) || IsPatternNight(date))
+            {
+                nights++;
+            }
+        }
+
+        decimal average = nights / 2m + holidayAdjustment;
+        return Math.Clamp(average, 0m, 365m);
+    }
+
+    private bool InSummerBlock(DateOnly date)
+    {
+        if (summerOvernights <= 0)
+        {
+            return false;
+        }
+
+        DateOnly blockStart = new(date.Year, 7, 1);
+        int daysFromStart = date.DayNumber - blockStart.DayNumber;
+        return daysFromStart >= 0 && daysFromStart < summerOvernights;
+    }
+
+    private bool IsPatternNight(DateOnly date)
+    {
+        bool weekendNight = date.DayOfWeek is DayOfWeek.Friday or DayOfWeek.Saturday
+            || (weekendsIncludeSunday && date.DayOfWeek is DayOfWeek.Sunday);
+
+        return pattern switch
+        {
+            "eow" => weekendNight && IsAlternatingWeekendOn(date),
+            "eow-midweek" => (weekendNight && IsAlternatingWeekendOn(date)) || date.DayOfWeek is DayOfWeek.Wednesday,
+            "first-third" => weekendNight && WeekendOrdinal(date) is 1 or 3,
+            "second-fourth" => weekendNight && WeekendOrdinal(date) is 2 or 4,
+            "every-weekend" => weekendNight,
+            _ => false,
+        };
+    }
+
+    // Alternating weekends anchor on the first Friday of 2026 (Jan 2) and flip every 7 days.
+    private static bool IsAlternatingWeekendOn(DateOnly date)
+    {
+        DateOnly anchor = new(2026, 1, 2);
+        int weeks = (date.DayNumber - anchor.DayNumber) / 7;
+        return ((weeks % 2) + 2) % 2 == 0;
+    }
+
+    // Which weekend of the month a night belongs to: the ordinal of its Friday within the
+    // Friday's month (a Saturday/Sunday night that crosses into a new month stays with its Friday).
+    private static int WeekendOrdinal(DateOnly date)
+    {
+        DateOnly friday = date.DayOfWeek switch
+        {
+            DayOfWeek.Saturday => date.AddDays(-1),
+            DayOfWeek.Sunday => date.AddDays(-2),
+            _ => date,
+        };
+
+        return (friday.Day - 1) / 7 + 1;
+    }
+}

--- a/src/FairShare.Web/Components/OregonWorksheet.razor
+++ b/src/FairShare.Web/Components/OregonWorksheet.razor
@@ -13,6 +13,11 @@
     the <a href="https://justice.oregon.gov/guidelines/" target="_blank" rel="noopener">official Oregon calculator</a>.
 </div>
 
+<p class="text-center small mb-3">
+    New to the Oregon guideline? Read
+    <a href="/guides/oregon-worksheet">Understanding the Oregon worksheet</a>.
+</p>
+
 <div class="row g-3 mb-2 justify-content-center">
     <div class="col-12 col-sm-6 col-lg-3 text-center">
         <label class="form-label" for="OR_JointMinors">Joint minor children</label>
@@ -78,6 +83,11 @@
     <div class="text-center small mb-3 @(OvernightsTotal == 365 ? "text-muted" : "text-danger")">
         Overnights entered: @OvernightsTotal.ToString("0.##") of 365
     </div>
+}
+
+@if (jointMinorChildren > 0)
+{
+    <OregonOvernightsHelper OnApply="ApplyOvernights" />
 }
 
 <div class="row g-4">
@@ -192,6 +202,12 @@
     private const string ApiUnreachableMessage = "The FairShare API could not be reached. Check your connection and try again.";
 
     private decimal OvernightsTotal => plaintiff.AverageOvernights + defendant.AverageOvernights;
+
+    private void ApplyOvernights((decimal Plaintiff, decimal Defendant) overnights)
+    {
+        plaintiff.AverageOvernights = overnights.Plaintiff;
+        defendant.AverageOvernights = overnights.Defendant;
+    }
 
     private async Task CalculateAsync()
     {

--- a/src/FairShare.Web/Pages/OregonGuide.razor
+++ b/src/FairShare.Web/Pages/OregonGuide.razor
@@ -1,0 +1,110 @@
+@page "/guides/oregon-worksheet"
+@attribute [AllowAnonymous]
+
+@* Plain-language walkthrough of the Oregon worksheet, distilled from the official instructions
+   (CSF 02 0910I) and the OAR 137-050 commentary. This is the "why is my number what it is" page;
+   the field-level "what do I type here" hints live on the calculator itself. Like /terms, keep the
+   copy literally true against the rules it cites. *@
+
+<PageTitle>FairShare - Understanding the Oregon worksheet</PageTitle>
+
+<div class="container my-5" style="max-width: 780px;">
+    <h1 class="h3 mb-1">Understanding the Oregon worksheet</h1>
+    <p class="text-muted mb-4">
+        OAR 137-050-0700 to -0765 &middot; the rules behind
+        <a href="/States/OR/Worksheet">FairShare's Oregon calculator</a> and the
+        <a href="https://justice.oregon.gov/guidelines/" target="_blank" rel="noopener">state's official calculator</a>.
+    </p>
+
+    <h2 class="h5">The big picture</h2>
+    <p>
+        Oregon uses the <strong>income shares</strong> model: the guideline estimates what the
+        parents would spend on the children if they lived together, then splits that amount in
+        proportion to each parent's income. Both parents' finances matter - there is no single
+        "payer's" formula.
+    </p>
+
+    <h2 class="h5 mt-4">Adjusted income (section 1)</h2>
+    <p>
+        Each parent starts from monthly income (actual, or what a parent <em>could</em> earn when a
+        court presumes potential income), then adds spousal support received and subtracts spousal
+        support paid, mandatory union dues, and the cost of the parent's <em>own</em> health
+        insurance. A parent supporting other children (non-joint children) gets a deduction computed
+        from the same scale. What remains is <strong>adjusted income</strong>, and each parent's
+        share of the combined total sets their share of everything that follows.
+    </p>
+
+    <h2 class="h5 mt-4">The self-support reserve</h2>
+    <p>
+        Before any support is measured, each parent keeps <strong>$1,729 a month</strong>
+        (OAR 137-050-0745, effective July 1, 2026) for their own basic needs - the amount tracks the
+        federal poverty guideline and is re-set every July 1. Support obligations cannot reach into
+        that reserve, which is why low incomes can produce small or minimum-level orders.
+    </p>
+
+    <h2 class="h5 mt-4">The basic support obligation (section 2)</h2>
+    <p>
+        The combined adjusted income and the number of joint children look up a monthly amount on
+        Oregon's <strong>obligation scale</strong>. The scale has rows every $50 up to $30,000 of
+        combined monthly income; between rows the <em>lower</em> row applies, and above $30,000 the
+        top row applies (a court can be asked to go higher). More than ten children use the
+        ten-child column.
+    </p>
+
+    <h2 class="h5 mt-4">Child care and health care (sections 3-5)</h2>
+    <p>
+        Work-related child care costs for children under 13 (or disabled) are shared by income
+        share. Health care coverage for the children is ordered from whichever parent can provide it
+        at a <strong>reasonable cost</strong> - capped at 4% of each parent's adjusted income, with
+        $0 expected from a parent earning at or below full-time highest Oregon minimum wage. When
+        neither parent has coverage available, <strong>cash medical support</strong> (that same
+        reasonable-cost amount) can be ordered instead. Whoever actually pays a cost gets credited
+        for it, so nothing is paid twice.
+    </p>
+
+    <h2 class="h5 mt-4">The parenting time credit (section 6)</h2>
+    <p>
+        Overnights matter from the very first one. The credit follows a smooth curve
+        (OAR 137-050-0730) - no cliffs, no thresholds: at zero overnights the credit is 0%, at
+        182.5 overnights (equal time) it is 50%, and at 365 it is 100%. The worksheet uses each
+        parent's <em>average annual overnights over two years</em>, and both parents' overnights
+        must total 365. Blocks of 4 to 12 hours without an overnight can count as half days.
+    </p>
+
+    <h2 class="h5 mt-4">Who pays (sections 7-9)</h2>
+    <p>
+        After credits, the parent with the higher net obligation for the minor children pays the
+        difference. A $100-a-month <strong>minimum order</strong> is presumed unless an exception
+        applies (incarceration, disability benefits as sole income, and similar). Social Security or
+        veterans benefits paid to the children because of a parent's disability or retirement reduce
+        that parent's obligation dollar for dollar.
+    </p>
+
+    <h2 class="h5 mt-4">Children Attending School</h2>
+    <p>
+        Oregon support does not stop at 18: an unmarried child aged 18 to 20 who is enrolled in
+        school at least half time is a <strong>Child Attending School</strong> (ORS 107.108), and
+        their share of support is paid <em>directly to the child</em>. That is why the worksheet can
+        obligate <em>both</em> parents at once, and why FairShare's Oregon results sometimes show
+        two amounts.
+    </p>
+
+    <h2 class="h5 mt-4">The number is a starting point</h2>
+    <p>
+        The guideline amount is presumed correct, but a court can adjust it for seventeen listed
+        <strong>rebuttal factors</strong> (OAR 137-050-0760) - other resources, special hardships,
+        the needs of other dependents, and more - and parents can agree to any amount within
+        <strong>&plusmn;15%</strong> of the guideline (OAR 137-050-0765). If a figure surprises
+        you, the worksheet lines on the calculator show exactly where it came from.
+    </p>
+
+    <p class="text-muted small mt-4 mb-0">
+        FairShare provides estimates for informational purposes only - not legal advice. Actual
+        support obligations are determined by the court under your state's guidelines. See the
+        <a href="/terms">terms</a>.
+    </p>
+
+    <div class="mt-4">
+        <a href="/States/OR/Worksheet" class="btn btn-link">&larr; Back to the Oregon calculator</a>
+    </div>
+</div>


### PR DESCRIPTION
Closes #129 · The second and final slice of the Oregon page (first slice: #139). (Re-landed via PR after an accidental direct push to main, which has been rewound.)

- **`OregonOvernightsHelper`** — the "Help me count overnights" expander next to the parent cards. Preset schedules (every-other-weekend with optional midweek/Sunday nights, 1st/3rd, 2nd/4th, every weekend, equal time), a July summer block (the state tool's 0–59 consecutive-nights idea — granted outright inside its window so pattern nights are never double counted), and a ± adjustment for holidays and OAR 137-050-0730 half-day equivalents. It counts nights on a **simulated 2026–2027 calendar and averages** — the same two-year-average semantics as Oregon's own parenting time calculator, which the helper links for schedules the presets can't express. The result fills both parents' overnights (totaling 365) and remains fully overridable in the cards, per the design decision (pattern-builder, not calendar replica).
- **`/guides/oregon-worksheet`** — the "why is my number what it is" page: income shares, the self-support reserve, the scale's lower-row/cap behavior, child care and the medical block, the parenting-time credit curve (0% → 50% at 182.5 → 100%, no cliffs), the $100 minimum order, Children Attending School and why results can show two amounts, and the rebuttal factors + ±15% band. Copy follows the /terms discipline: literally true against the rules it cites. Anonymous like /privacy and /terms.

315 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)