### PR TITLE
fix(deps): batch the August dependabot bumps with the Swashbuckle 10 port

### DIFF
--- a/src/FairShare.Api/FairShare.Api.csproj
+++ b/src/FairShare.Api/FairShare.Api.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11" PrivateAssets="all"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
     <PackageReference Include="ClosedXML" Version="0.105.1"/>
   </ItemGroup>
 

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -38,29 +38,22 @@ builder.Services.AddSwaggerGen(options =>
 {
     options.SwaggerDoc("v1", new() { Title = "FairShare API", Version = "v1" });
 
-    options.AddSecurityDefinition("Bearer", new()
+    // Swashbuckle 10 rides Microsoft.OpenApi 2.x: the Models namespace folded into
+    // Microsoft.OpenApi, schemes are referenced through OpenApiSecuritySchemeReference, and the
+    // requirement is built per document.
+    options.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.OpenApiSecurityScheme
     {
         Name = "Authorization",
-        Type = Microsoft.OpenApi.Models.SecuritySchemeType.ApiKey,
+        Type = Microsoft.OpenApi.SecuritySchemeType.ApiKey,
         Scheme = "Bearer",
         BearerFormat = "JWT",
-        In = Microsoft.OpenApi.Models.ParameterLocation.Header,
+        In = Microsoft.OpenApi.ParameterLocation.Header,
         Description = "Enter 'Bearer {token}'"
     });
 
-    options.AddSecurityRequirement(new()
+    options.AddSecurityRequirement(document => new Microsoft.OpenApi.OpenApiSecurityRequirement
     {
-        {
-            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
-            {
-                Reference = new Microsoft.OpenApi.Models.OpenApiReference
-                {
-                    Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
-                    Id = "Bearer"
-                }
-            },
-            Array.Empty<string>()
-        }
+        [new Microsoft.OpenApi.OpenApiSecuritySchemeReference("Bearer", document)] = new List<string>()
     });
 });
 

--- a/src/FairShare.Tests/FairShare.Tests.csproj
+++ b/src/FairShare.Tests/FairShare.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageReference Include="ClosedXML" Version="0.105.1" />
   </ItemGroup>


### PR DESCRIPTION
Supersedes and closes the four open dependabot PRs (#121–#124), per the repo's PR-#91 precedent of one tested, consolidated bump.

- **Swashbuckle.AspNetCore 7.2.0 → 10.2.3** — the one non-trivial bump: Swashbuckle 10 rides Microsoft.OpenApi 2.x, whose model reshape breaks the swagger security config (the `Models` namespace folded into `Microsoft.OpenApi`, schemes are referenced via `OpenApiSecuritySchemeReference`, and `AddSecurityRequirement` now takes a per-document function). Ported in `Program.cs` and **verified at runtime**: `/swagger/v1/swagger.json` serves an OpenAPI 3.0.4 document with the Bearer `securityScheme`, the global `security` requirement, and all 35 paths.
- **Microsoft.NET.Test.Sdk 17.12.0 → 18.9.0** and **xunit.runner.visualstudio 2.8.2 → 4.0.0** — the discovery-silently-breaks risk was checked explicitly: exactly **315 tests still run** (the full count), none dropped.
- **xunit 2.9.2 → 2.9.3** — patch.

Closes #121
Closes #122
Closes #123
Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)