### PR TITLE
feat: saved Scenarios - schema, API, and recompute-with-notice semantics (ADR 0006)

### DIFF
--- a/src/FairShare.Api/Controllers/CalculationsController.cs
+++ b/src/FairShare.Api/Controllers/CalculationsController.cs
@@ -2,9 +2,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FairShare.Api.Observability;
+using FairShare.Api.Services;
 using FairShare.Api.Services.Export;
 using FairShare.Contracts.Calculation;
-using FairShare.Domain.Calculators;
 using FairShare.Domain.Helpers;
 using FairShare.Domain.Interfaces;
 using FairShare.Domain.Models;
@@ -16,69 +16,39 @@ namespace FairShare.Api.Controllers;
 [ApiController]
 [Route("api/v1/states/{state}/forms/{form}/calculations")]
 [Authorize]
-public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetExporter exporter, IAnalyticsService analytics) : ControllerBase
+public class CalculationsController(IStateGuidelineCatalog catalog, ICalculationRunner runner, IWorksheetExporter exporter, IAnalyticsService analytics) : ControllerBase
 {
     private readonly IStateGuidelineCatalog _catalog = catalog;
+    private readonly ICalculationRunner _runner = runner;
     private readonly IWorksheetExporter _exporter = exporter;
     private readonly IAnalyticsService _analytics = analytics;
 
     [HttpPost]
     public async Task<ActionResult<CalculationResponse>> Calculate(string state, string form, [FromBody] CalculationRequest request, CancellationToken ct)
     {
-        IWorksheetForm? formEntry = _catalog.GetForm(state, form);
-
-        if (formEntry is null)
-        {
-            return NotFound(new { message = $"No calculator registered for {state}/{form}." });
-        }
-
         // Engagement telemetry (ADR 0003): the form key is the whole target - never inputs
         // or results. "started" = a calculation was attempted, "completed" = it succeeded.
         string eventTarget = $"{state}/{form}".ToLowerInvariant();
         await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationStarted, eventTarget, ct);
 
-        CalculationResult result;
+        CalculationRun run = _runner.Run(state, form, request);
 
-        if (formEntry is IChildSupportCalculator calculator)
-        {
-            ParentData plaintiff = ToParentData(request.Plaintiff);
-            ParentData defendant = ToParentData(request.Defendant);
-
-            result = calculator.Calculate(plaintiff, defendant, request.NumberOfChildren);
-        }
-        else if (formEntry is OregonWorksheetCalculator oregonCalculator)
-        {
-            if (request.Oregon is null)
-            {
-                return BadRequest(new { message = $"{state}/{form} requires the request's 'oregon' inputs." });
-            }
-
-            if (!TryMapOregonInput(request.Oregon, out OregonWorksheetInput? oregonInput, out string? mappingError))
-            {
-                return BadRequest(new { message = mappingError });
-            }
-
-            OregonCalculationOutcome outcome = oregonCalculator.Calculate(oregonInput!);
-            result = ToCalculationResult(oregonCalculator, request.Oregon, outcome);
-
-            if (outcome.Success)
-            {
-                await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationCompleted, eventTarget, ct);
-            }
-
-            return Ok(ToResponse(result, ToOregonDto(outcome)));
-        }
-        else
+        if (!run.FormFound)
         {
             return NotFound(new { message = $"No calculator registered for {state}/{form}." });
         }
 
-        if (result.Success)
+        if (run.InputError is not null)
+        {
+            return BadRequest(new { message = run.InputError });
+        }
+
+        if (run.Response!.Success)
         {
             await _analytics.RecordEventAsync(HttpContext, AnalyticsEventNames.CalculationCompleted, eventTarget, ct);
         }
 
-        return Ok(ToResponse(result));
+        return Ok(run.Response);
     }
 
     /// <summary>
@@ -96,135 +66,21 @@ public class CalculationsController(IStateGuidelineCatalog catalog, IWorksheetEx
             return NotFound(new { message = $"No worksheet export available for {state}/{form}." });
         }
 
+        CalculationRun check = _runner.Run(state, form, request);
+
+        if (check.Response is not { Success: true })
+        {
+            return BadRequest(check.Response ?? new CalculationResponse { Success = false });
+        }
+
         ParentData plaintiff = ToParentData(request.Plaintiff);
         ParentData defendant = ToParentData(request.Defendant);
-
-        CalculationResult check = calculator.Calculate(plaintiff, defendant, request.NumberOfChildren);
-
-        if (!check.Success)
-        {
-            return BadRequest(ToResponse(check));
-        }
 
         WorksheetExport export = _exporter.Export(new WorksheetExportInput(
             state, form, request.NumberOfChildren, plaintiff, defendant, request.PlaintiffName, request.DefendantName));
 
         return File(export.Content, export.ContentType, export.FileName);
     }
-
-    /// <summary>
-    /// Folds an Oregon outcome into the shared result shape: the headline payer is line 7c's
-    /// parent (empty when neither pays for the minors) and the headline amount is that parent's
-    /// line 9e total; both parents' totals travel in the Oregon extras.
-    /// </summary>
-    private static CalculationResult ToCalculationResult(OregonWorksheetCalculator calculator, OregonCalculationRequest request, OregonCalculationOutcome outcome)
-        => new(outcome.PaysForMinorChildren?.ToString() ?? string.Empty,
-               // Line 9e is whole-dollar by construction (9a-9d each round to the dollar), so this
-               // rounding is a guard against truncation, not a change of value.
-               (int)Math.Round(outcome.PaysForMinorChildren switch
-               {
-                   Enums.ParentType.Plaintiff => outcome.PlaintiffTotalSupport,
-                   Enums.ParentType.Defendant => outcome.DefendantTotalSupport,
-                   _ => 0m,
-               }, 0, MidpointRounding.AwayFromZero))
-        {
-            Success = outcome.Success,
-            Errors = [.. outcome.Errors],
-            State = calculator.State,
-            Form = calculator.Form,
-            NumberOfChildren = request.JointMinorChildren + request.JointChildrenAttendingSchool,
-            Lines = outcome.Lines,
-        };
-
-    private static OregonResultDto ToOregonDto(OregonCalculationOutcome outcome)
-        => new()
-        {
-            PlaintiffTotalSupport = outcome.PlaintiffTotalSupport,
-            DefendantTotalSupport = outcome.DefendantTotalSupport,
-            PaysForMinorChildren = outcome.PaysForMinorChildren?.ToString(),
-            CoverageProvider = outcome.CoverageProvider.ToString(),
-            ReasonableCostTotal = outcome.ReasonableCostTotal,
-            RuleEffectiveDate = outcome.RuleEffectiveDate.ToString("yyyy-MM-dd"),
-        };
-
-    private static bool TryMapOregonInput(OregonCalculationRequest dto, out OregonWorksheetInput? input, out string? error)
-    {
-        input = null;
-
-        if (!Enum.TryParse(dto.CashMedical, ignoreCase: true, out CashMedicalElection cashMedical))
-        {
-            error = "cashMedical must be \"No\", \"Yes\", or \"Contingent\".";
-            return false;
-        }
-
-        CoverageProvider? selection = null;
-        if (dto.CoverageSelection is { } selectionText)
-        {
-            if (!Enum.TryParse(selectionText, ignoreCase: true, out CoverageProvider parsed))
-            {
-                error = "coverageSelection must be \"Plaintiff\", \"Defendant\", \"Both\", or \"EitherWhenAvailable\".";
-                return false;
-            }
-
-            selection = parsed;
-        }
-
-        input = new OregonWorksheetInput
-        {
-            Plaintiff = ToOregonParent(dto.Plaintiff),
-            Defendant = ToOregonParent(dto.Defendant),
-            JointMinorChildren = dto.JointMinorChildren,
-            JointChildrenAttendingSchool = dto.JointChildrenAttendingSchool,
-            CashMedical = cashMedical,
-            CoverageSelection = selection,
-            OrderCoverageAtHigherAmount = dto.OrderCoverageAtHigherAmount,
-        };
-        error = null;
-        return true;
-    }
-
-    private static OregonParentInput ToOregonParent(OregonParentDto dto) => new()
-    {
-        MonthlyIncome = dto.MonthlyIncome,
-        SpousalSupportReceived = dto.SpousalSupportReceived,
-        SpousalSupportPaid = dto.SpousalSupportPaid,
-        UnionDues = dto.UnionDues,
-        OwnHealthInsuranceCost = dto.OwnHealthInsuranceCost,
-        NonJointChildren = dto.NonJointChildren,
-        ChildCareCosts = dto.ChildCareCosts,
-        ChildrensHealthCoverageCost = dto.ChildrensHealthCoverageCost,
-        AverageOvernights = dto.AverageOvernights,
-        SocialSecurityVeteransBenefits = dto.SocialSecurityVeteransBenefits,
-        MinimumOrderException = dto.MinimumOrderException,
-    };
-
-    private static CalculationResponse ToResponse(CalculationResult result, OregonResultDto? oregon = null)
-        => new()
-        {
-            Oregon = oregon,
-            Success = result.Success,
-            State = result.State,
-            Form = result.Form,
-            NumberOfChildren = result.NumberOfChildren,
-            Payer = result.Payer,
-            FinalAmount = result.FinalAmount,
-            Errors = result.Errors.Select(e => new CalcErrorDto
-            {
-                Code = e.Code,
-                Message = e.Message,
-                Field = e.Field,
-                Severity = e.Severity.ToString()
-            }).ToList(),
-            Lines = result.Lines.Select(l => new WorksheetLineDto
-            {
-                Number = l.Number,
-                Label = l.Label,
-                Plaintiff = l.Plaintiff,
-                Defendant = l.Defendant,
-                Combined = l.Combined,
-                Format = l.Format.ToString()
-            }).ToList()
-        };
 
     private static ParentData ToParentData(ParentDataDto dto) => new()
     {

--- a/src/FairShare.Api/Controllers/ScenariosController.cs
+++ b/src/FairShare.Api/Controllers/ScenariosController.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Models;
+using FairShare.Api.Services;
+using FairShare.Contracts.Calculation;
+using FairShare.Contracts.Scenarios;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FairShare.Api.Controllers;
+
+/// <summary>
+/// Saved Scenarios (ADR 0006). A gated feature: guests calculate freely but only signed-in users
+/// persist, so the whole controller requires a non-guest account. Scenarios are strictly
+/// owner-scoped - there is no admin cross-access to other people's saved cases-in-planning.
+/// </summary>
+[Authorize(Policy = "NotGuest")]
+[Route("api/v1/scenarios")]
+[ApiController]
+public class ScenariosController(IScenarioService scenarios, ICalculationRunner runner) : ControllerBase
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly IScenarioService _scenarios = scenarios;
+    private readonly ICalculationRunner _runner = runner;
+
+    private Guid? CurrentUserId =>
+        Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var g) ? g : null;
+
+    [HttpGet]
+    public async Task<IActionResult> List(CancellationToken ct)
+    {
+        if (CurrentUserId is not Guid uid)
+        {
+            return Forbid();
+        }
+
+        var list = await _scenarios.ListForOwnerAsync(uid, ct);
+        return Ok(list.Select(ToSummary));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Save([FromBody] ScenarioSaveRequest request, CancellationToken ct)
+    {
+        if (CurrentUserId is not Guid uid)
+        {
+            return Forbid();
+        }
+
+        // The server computes the snapshot itself; a client-supplied result is never trusted.
+        CalculationRun run = _runner.Run(request.State, request.Form, request.Inputs);
+
+        if (!run.FormFound)
+        {
+            return NotFound(new { message = $"No calculator registered for {request.State}/{request.Form}." });
+        }
+
+        if (run.InputError is not null)
+        {
+            return BadRequest(new { message = run.InputError });
+        }
+
+        if (run.Response is not { Success: true } response)
+        {
+            // A scenario exists to preserve a number the user saw; inputs the worksheet rejects
+            // have no number to preserve.
+            return UnprocessableEntity(run.Response);
+        }
+
+        SavedScenario scenario = new()
+        {
+            Name = request.Name.Trim(),
+            State = response.State,
+            Form = response.Form,
+            OwnerUserId = uid,
+            InputsJson = JsonSerializer.Serialize(request.Inputs, Json),
+            SnapshotJson = JsonSerializer.Serialize(WithoutLines(response), Json),
+            RuleEffectiveDate = response.Oregon?.RuleEffectiveDate,
+        };
+
+        (SavedScenario saved, bool created) = await _scenarios.UpsertByNameAsync(scenario, ct);
+
+        return created
+            ? CreatedAtAction(nameof(Get), new { id = saved.Id }, ToSummary(saved))
+            : Ok(ToSummary(saved));
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> Get(Guid id, CancellationToken ct)
+    {
+        SavedScenario? scenario = await OwnedAsync(id, ct);
+
+        if (scenario is null)
+        {
+            return NotFound();
+        }
+
+        CalculationRequest inputs = JsonSerializer.Deserialize<CalculationRequest>(scenario.InputsJson, Json) ?? new();
+        CalculationResponse snapshot = JsonSerializer.Deserialize<CalculationResponse>(scenario.SnapshotJson, Json) ?? new();
+
+        // ADR 0006: reopening always recomputes under the CURRENT rules and says so when the
+        // number moved - a saved figure is never silently changed and never silently stale.
+        CalculationRun run = _runner.Run(scenario.State, scenario.Form, inputs);
+        CalculationResponse? current = run.FormFound && run.InputError is null ? run.Response : null;
+
+        ScenarioDetailDto detail = new()
+        {
+            Inputs = inputs,
+            Snapshot = snapshot,
+            Current = current,
+            ResultChanged = current is not null && ResultsDiffer(snapshot, current),
+        };
+        Populate(detail, scenario);
+
+        return Ok(detail);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        SavedScenario? scenario = await OwnedAsync(id, ct);
+
+        if (scenario is null)
+        {
+            return NotFound();
+        }
+
+        await _scenarios.DeleteAsync(id, ct);
+        return NoContent();
+    }
+
+    /// <summary>The scenario when it exists and belongs to the caller; owner mismatches read as 404, never 403.</summary>
+    private async Task<SavedScenario?> OwnedAsync(Guid id, CancellationToken ct)
+    {
+        SavedScenario? scenario = await _scenarios.GetAsync(id, ct);
+        return scenario is not null && scenario.OwnerUserId == CurrentUserId ? scenario : null;
+    }
+
+    /// <summary>What "the number moved" means: the headline or either Oregon total differs.</summary>
+    public static bool ResultsDiffer(CalculationResponse snapshot, CalculationResponse current)
+        => snapshot.Payer != current.Payer
+            || snapshot.FinalAmount != current.FinalAmount
+            || snapshot.Oregon?.PlaintiffTotalSupport != current.Oregon?.PlaintiffTotalSupport
+            || snapshot.Oregon?.DefendantTotalSupport != current.Oregon?.DefendantTotalSupport;
+
+    private static CalculationResponse WithoutLines(CalculationResponse response) => new()
+    {
+        Success = response.Success,
+        Errors = response.Errors,
+        State = response.State,
+        Form = response.Form,
+        NumberOfChildren = response.NumberOfChildren,
+        Payer = response.Payer,
+        FinalAmount = response.FinalAmount,
+        Oregon = response.Oregon,
+        Lines = [],
+    };
+
+    private ScenarioSummaryDto ToSummary(SavedScenario scenario)
+    {
+        ScenarioSummaryDto dto = new();
+        Populate(dto, scenario);
+        return dto;
+    }
+
+    private void Populate(ScenarioSummaryDto dto, SavedScenario scenario)
+    {
+        CalculationResponse snapshot = JsonSerializer.Deserialize<CalculationResponse>(scenario.SnapshotJson, Json) ?? new();
+
+        dto.Id = scenario.Id;
+        dto.Name = scenario.Name;
+        dto.State = scenario.State;
+        dto.Form = scenario.Form;
+        dto.Payer = snapshot.Payer;
+        dto.FinalAmount = snapshot.FinalAmount;
+        dto.RuleEffectiveDate = scenario.RuleEffectiveDate;
+        dto.CreatedUtc = scenario.CreatedUtc;
+        dto.UpdatedUtc = scenario.UpdatedUtc;
+    }
+}

--- a/src/FairShare.Api/Migrations/20260823200215_AddScenarios.Designer.cs
+++ b/src/FairShare.Api/Migrations/20260823200215_AddScenarios.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FairShare.Api.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FairShare.Api.Migrations
 {
     [DbContext(typeof(FairShareDbContext))]
-    partial class FairShareDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823200215_AddScenarios")]
+    partial class AddScenarios
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/src/FairShare.Api/Migrations/20260823200215_AddScenarios.cs
+++ b/src/FairShare.Api/Migrations/20260823200215_AddScenarios.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FairShare.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScenarios : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Scenarios",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    State = table.Column<string>(type: "TEXT", maxLength: 2, nullable: false),
+                    Form = table.Column<string>(type: "TEXT", maxLength: 40, nullable: false),
+                    InputsJson = table.Column<string>(type: "TEXT", nullable: false),
+                    SnapshotJson = table.Column<string>(type: "TEXT", nullable: false),
+                    RuleEffectiveDate = table.Column<string>(type: "TEXT", maxLength: 10, nullable: true),
+                    OwnerUserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    UpdatedUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    RowVersion = table.Column<byte[]>(type: "BLOB", rowVersion: true, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Scenarios", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Scenarios_AspNetUsers_OwnerUserId",
+                        column: x => x.OwnerUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Scenarios_OwnerUserId_Name",
+                table: "Scenarios",
+                columns: new[] { "OwnerUserId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Scenarios");
+        }
+    }
+}

--- a/src/FairShare.Api/Models/SavedScenario.cs
+++ b/src/FairShare.Api/Models/SavedScenario.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace FairShare.Api.Models;
+
+/// <summary>
+/// A Scenario (see CONTEXT.md): a named snapshot of one worksheet's inputs for a state and form,
+/// stamped with the rule version and result it was computed under (ADR 0006). The inputs and
+/// snapshot are stored as the wire JSON of the calculation contract, which keeps the schema
+/// state-agnostic - Alabama and Oregon scenarios share this table unchanged.
+/// </summary>
+public class SavedScenario
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required, MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required, MaxLength(2)]
+    public string State { get; set; } = string.Empty;
+
+    [Required, MaxLength(40)]
+    public string Form { get; set; } = string.Empty;
+
+    /// <summary>The CalculationRequest JSON the scenario was saved with.</summary>
+    [Required]
+    public string InputsJson { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The CalculationResponse JSON (without worksheet lines) the inputs produced at save time -
+    /// the number the user saw, preserved verbatim so a reopen can say whether today's rules moved it.
+    /// </summary>
+    [Required]
+    public string SnapshotJson { get; set; } = string.Empty;
+
+    /// <summary>The guideline effective date the snapshot was computed under (ISO date), when the form has one.</summary>
+    [MaxLength(10)]
+    public string? RuleEffectiveDate { get; set; }
+
+    /// <summary>Scenarios are strictly owned - they exist only for signed-in users and die with the account.</summary>
+    public Guid OwnerUserId { get; set; }
+
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedUtc { get; set; }
+
+    [Timestamp]
+    public byte[]? RowVersion { get; set; }
+}

--- a/src/FairShare.Api/Persistence/FairShareDbContext.cs
+++ b/src/FairShare.Api/Persistence/FairShareDbContext.cs
@@ -16,6 +16,7 @@ public class FairShareDbContext : IdentityDbContext<ApplicationUser, IdentityRol
     public FairShareDbContext(DbContextOptions<FairShareDbContext> options) : base(options) { }
 
     public DbSet<ParentProfile> ParentProfiles => Set<ParentProfile>();
+    public DbSet<SavedScenario> Scenarios => Set<SavedScenario>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<LogEntry> Logs => Set<LogEntry>();
     public DbSet<AuditEvent> AuditEvents => Set<AuditEvent>();
@@ -66,6 +67,24 @@ public class FairShareDbContext : IdentityDbContext<ApplicationUser, IdentityRol
              .WithMany()
              .HasForeignKey(p => p.OwnerUserId)
              .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<SavedScenario>(b =>
+        {
+            b.HasKey(s => s.Id);
+            b.Property(s => s.RowVersion).IsRowVersion();
+            b.Property(s => s.CreatedUtc).HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            // The name is the natural key within one user's scenarios (the service matches
+            // case-insensitively; this index backstops exact duplicates under concurrency).
+            b.HasIndex(s => new { s.OwnerUserId, s.Name }).IsUnique();
+
+            // Scenarios are strictly owned and die with the account (unlike ParentProfiles,
+            // whose nullable owner predates accounts).
+            b.HasOne<ApplicationUser>()
+             .WithMany()
+             .HasForeignKey(s => s.OwnerUserId)
+             .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<LogEntry>(b =>

--- a/src/FairShare.Api/Program.cs
+++ b/src/FairShare.Api/Program.cs
@@ -233,6 +233,8 @@ builder.Services.AddScoped<IWorksheetForm, CS42Calculator>();
 builder.Services.AddScoped<IWorksheetForm, CS42SCalculator>();
 builder.Services.AddScoped<IWorksheetForm, OregonWorksheetCalculator>();
 builder.Services.AddScoped<IStateGuidelineCatalog, StateGuidelineCatalog>();
+builder.Services.AddScoped<ICalculationRunner, CalculationRunner>();
+builder.Services.AddScoped<IScenarioService, ScenarioService>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IWorksheetExporter, ClosedXmlWorksheetExporter>();
 builder.Services.AddScoped<IParentProfileService, ParentProfileService>();

--- a/src/FairShare.Api/Services/CalculationRunner.cs
+++ b/src/FairShare.Api/Services/CalculationRunner.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Linq;
+using FairShare.Contracts.Calculation;
+using FairShare.Domain.Calculators;
+using FairShare.Domain.Helpers;
+using FairShare.Domain.Interfaces;
+using FairShare.Domain.Models;
+using static FairShare.Domain.Helpers.Enums;
+
+namespace FairShare.Api.Services;
+
+/// <summary>
+/// The outcome of dispatching one calculation request. <see cref="FormFound"/> false maps to 404;
+/// a non-null <see cref="InputError"/> maps to 400; otherwise <see cref="Response"/> is set (its
+/// own Success flag distinguishes computed results from validation errors inside the worksheet).
+/// </summary>
+public sealed record CalculationRun(bool FormFound, string? InputError, CalculationResponse? Response);
+
+/// <summary>
+/// Runs a calculation request against the right calculator for a (state, form) - the shared engine
+/// behind the calculations endpoint and saved scenarios (which recompute on save and on reopen).
+/// </summary>
+public interface ICalculationRunner
+{
+    CalculationRun Run(string state, string form, CalculationRequest request);
+}
+
+public sealed class CalculationRunner(IStateGuidelineCatalog catalog) : ICalculationRunner
+{
+    private readonly IStateGuidelineCatalog _catalog = catalog;
+
+    public CalculationRun Run(string state, string form, CalculationRequest request)
+    {
+        IWorksheetForm? formEntry = _catalog.GetForm(state, form);
+
+        if (formEntry is IChildSupportCalculator calculator)
+        {
+            CalculationResult result = calculator.Calculate(
+                ToParentData(request.Plaintiff), ToParentData(request.Defendant), request.NumberOfChildren);
+
+            return new CalculationRun(true, null, ToResponse(result));
+        }
+
+        if (formEntry is OregonWorksheetCalculator oregonCalculator)
+        {
+            if (request.Oregon is null)
+            {
+                return new CalculationRun(true, $"{state}/{form} requires the request's 'oregon' inputs.", null);
+            }
+
+            if (!TryMapOregonInput(request.Oregon, out OregonWorksheetInput? oregonInput, out string? mappingError))
+            {
+                return new CalculationRun(true, mappingError, null);
+            }
+
+            OregonCalculationOutcome outcome = oregonCalculator.Calculate(oregonInput!);
+            CalculationResult result = ToCalculationResult(oregonCalculator, request.Oregon, outcome);
+
+            return new CalculationRun(true, null, ToResponse(result, ToOregonDto(outcome)));
+        }
+
+        return new CalculationRun(false, null, null);
+    }
+
+    /// <summary>
+    /// Folds an Oregon outcome into the shared result shape: the headline payer is line 7c's
+    /// parent (empty when neither pays for the minors) and the headline amount is that parent's
+    /// line 9e total; both parents' totals travel in the Oregon extras.
+    /// </summary>
+    private static CalculationResult ToCalculationResult(OregonWorksheetCalculator calculator, OregonCalculationRequest request, OregonCalculationOutcome outcome)
+        => new(outcome.PaysForMinorChildren?.ToString() ?? string.Empty,
+               // Line 9e is whole-dollar by construction (9a-9d each round to the dollar), so this
+               // rounding is a guard against truncation, not a change of value.
+               (int)Math.Round(outcome.PaysForMinorChildren switch
+               {
+                   ParentType.Plaintiff => outcome.PlaintiffTotalSupport,
+                   ParentType.Defendant => outcome.DefendantTotalSupport,
+                   _ => 0m,
+               }, 0, MidpointRounding.AwayFromZero))
+        {
+            Success = outcome.Success,
+            Errors = [.. outcome.Errors],
+            State = calculator.State,
+            Form = calculator.Form,
+            NumberOfChildren = request.JointMinorChildren + request.JointChildrenAttendingSchool,
+            Lines = outcome.Lines,
+        };
+
+    private static OregonResultDto ToOregonDto(OregonCalculationOutcome outcome)
+        => new()
+        {
+            PlaintiffTotalSupport = outcome.PlaintiffTotalSupport,
+            DefendantTotalSupport = outcome.DefendantTotalSupport,
+            PaysForMinorChildren = outcome.PaysForMinorChildren?.ToString(),
+            CoverageProvider = outcome.CoverageProvider.ToString(),
+            ReasonableCostTotal = outcome.ReasonableCostTotal,
+            RuleEffectiveDate = outcome.RuleEffectiveDate.ToString("yyyy-MM-dd"),
+        };
+
+    private static bool TryMapOregonInput(OregonCalculationRequest dto, out OregonWorksheetInput? input, out string? error)
+    {
+        input = null;
+
+        if (!Enum.TryParse(dto.CashMedical, ignoreCase: true, out CashMedicalElection cashMedical))
+        {
+            error = "cashMedical must be \"No\", \"Yes\", or \"Contingent\".";
+            return false;
+        }
+
+        CoverageProvider? selection = null;
+        if (dto.CoverageSelection is { } selectionText)
+        {
+            if (!Enum.TryParse(selectionText, ignoreCase: true, out CoverageProvider parsed))
+            {
+                error = "coverageSelection must be \"Plaintiff\", \"Defendant\", \"Both\", or \"EitherWhenAvailable\".";
+                return false;
+            }
+
+            selection = parsed;
+        }
+
+        input = new OregonWorksheetInput
+        {
+            Plaintiff = ToOregonParent(dto.Plaintiff),
+            Defendant = ToOregonParent(dto.Defendant),
+            JointMinorChildren = dto.JointMinorChildren,
+            JointChildrenAttendingSchool = dto.JointChildrenAttendingSchool,
+            CashMedical = cashMedical,
+            CoverageSelection = selection,
+            OrderCoverageAtHigherAmount = dto.OrderCoverageAtHigherAmount,
+        };
+        error = null;
+        return true;
+    }
+
+    private static OregonParentInput ToOregonParent(OregonParentDto dto) => new()
+    {
+        MonthlyIncome = dto.MonthlyIncome,
+        SpousalSupportReceived = dto.SpousalSupportReceived,
+        SpousalSupportPaid = dto.SpousalSupportPaid,
+        UnionDues = dto.UnionDues,
+        OwnHealthInsuranceCost = dto.OwnHealthInsuranceCost,
+        NonJointChildren = dto.NonJointChildren,
+        ChildCareCosts = dto.ChildCareCosts,
+        ChildrensHealthCoverageCost = dto.ChildrensHealthCoverageCost,
+        AverageOvernights = dto.AverageOvernights,
+        SocialSecurityVeteransBenefits = dto.SocialSecurityVeteransBenefits,
+        MinimumOrderException = dto.MinimumOrderException,
+    };
+
+    private static CalculationResponse ToResponse(CalculationResult result, OregonResultDto? oregon = null)
+        => new()
+        {
+            Oregon = oregon,
+            Success = result.Success,
+            State = result.State,
+            Form = result.Form,
+            NumberOfChildren = result.NumberOfChildren,
+            Payer = result.Payer,
+            FinalAmount = result.FinalAmount,
+            Errors = result.Errors.Select(e => new CalcErrorDto
+            {
+                Code = e.Code,
+                Message = e.Message,
+                Field = e.Field,
+                Severity = e.Severity.ToString()
+            }).ToList(),
+            Lines = result.Lines.Select(l => new WorksheetLineDto
+            {
+                Number = l.Number,
+                Label = l.Label,
+                Plaintiff = l.Plaintiff,
+                Defendant = l.Defendant,
+                Combined = l.Combined,
+                Format = l.Format.ToString()
+            }).ToList()
+        };
+
+    private static ParentData ToParentData(ParentDataDto dto) => new()
+    {
+        MonthlyGrossIncome = dto.MonthlyGrossIncome,
+        PreexistingChildSupport = dto.PreexistingChildSupport,
+        PreexistingAlimony = dto.PreexistingAlimony,
+        WorkRelatedChildcareCosts = dto.WorkRelatedChildcareCosts,
+        HealthcareCoverageCosts = dto.HealthcareCoverageCosts,
+        HasPrimaryCustody = dto.HasPrimaryCustody
+    };
+}

--- a/src/FairShare.Api/Services/ScenarioService.cs
+++ b/src/FairShare.Api/Services/ScenarioService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FairShare.Api.Models;
+using FairShare.Api.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FairShare.Api.Services;
+
+public interface IScenarioService
+{
+    Task<IReadOnlyList<SavedScenario>> ListForOwnerAsync(Guid ownerUserId, CancellationToken ct = default);
+    Task<SavedScenario?> GetAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Saves a scenario, updating in place when the owner already has one with this name -
+    /// the name is the natural key within one user's scenarios, like saved parents.
+    /// </summary>
+    Task<(SavedScenario Scenario, bool Created)> UpsertByNameAsync(SavedScenario scenario, CancellationToken ct = default);
+
+    Task<bool> DeleteAsync(Guid id, CancellationToken ct = default);
+}
+
+public class ScenarioService(FairShareDbContext db) : IScenarioService
+{
+    private readonly FairShareDbContext _db = db;
+
+    public async Task<IReadOnlyList<SavedScenario>> ListForOwnerAsync(Guid ownerUserId, CancellationToken ct = default)
+        => await _db.Scenarios
+            .Where(s => s.OwnerUserId == ownerUserId)
+            .OrderByDescending(s => s.UpdatedUtc ?? s.CreatedUtc)
+            .Take(100)
+            .ToListAsync(ct);
+
+    public Task<SavedScenario?> GetAsync(Guid id, CancellationToken ct = default)
+        => _db.Scenarios.FirstOrDefaultAsync(s => s.Id == id, ct);
+
+    public async Task<(SavedScenario Scenario, bool Created)> UpsertByNameAsync(SavedScenario scenario, CancellationToken ct = default)
+    {
+        // Case-insensitive match so "Trial" and "trial" never accumulate as twins; the DB's
+        // unique (OwnerUserId, Name) index backstops exact duplicates under concurrency.
+        string nameLower = scenario.Name.ToLowerInvariant();
+        SavedScenario? existing = await _db.Scenarios.FirstOrDefaultAsync(
+            s => s.OwnerUserId == scenario.OwnerUserId && s.Name.ToLower() == nameLower, ct);
+
+        if (existing is null)
+        {
+            _db.Scenarios.Add(scenario);
+            await _db.SaveChangesAsync(ct);
+            return (scenario, true);
+        }
+
+        existing.Name = scenario.Name;
+        existing.State = scenario.State;
+        existing.Form = scenario.Form;
+        existing.InputsJson = scenario.InputsJson;
+        existing.SnapshotJson = scenario.SnapshotJson;
+        existing.RuleEffectiveDate = scenario.RuleEffectiveDate;
+        existing.UpdatedUtc = DateTime.UtcNow;
+        await _db.SaveChangesAsync(ct);
+        return (existing, false);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        SavedScenario? existing = await _db.Scenarios.FirstOrDefaultAsync(s => s.Id == id, ct);
+
+        if (existing is null)
+        {
+            return false;
+        }
+
+        _db.Scenarios.Remove(existing);
+        await _db.SaveChangesAsync(ct);
+        return true;
+    }
+}

--- a/src/FairShare.Contracts/Scenarios/ScenarioContracts.cs
+++ b/src/FairShare.Contracts/Scenarios/ScenarioContracts.cs
@@ -1,0 +1,58 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using FairShare.Contracts.Calculation;
+
+namespace FairShare.Contracts.Scenarios;
+
+/// <summary>
+/// Saves (or updates, when the name already exists for this user) a Scenario: the full inputs of
+/// one worksheet for one state and form. The server recomputes the result itself - the snapshot is
+/// never taken from the client.
+/// </summary>
+public class ScenarioSaveRequest
+{
+    [Required, MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required, MaxLength(2)]
+    public string State { get; set; } = string.Empty;
+
+    [Required, MaxLength(40)]
+    public string Form { get; set; } = string.Empty;
+
+    [Required]
+    public CalculationRequest Inputs { get; set; } = new();
+}
+
+public class ScenarioSummaryDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string State { get; set; } = string.Empty;
+    public string Form { get; set; } = string.Empty;
+
+    /// <summary>The saved result's headline: who pays ("Plaintiff"/"Defendant", empty for none) and how much.</summary>
+    public string Payer { get; set; } = string.Empty;
+    public int FinalAmount { get; set; }
+
+    /// <summary>The guideline effective date the snapshot was computed under, when the form has one.</summary>
+    public string? RuleEffectiveDate { get; set; }
+
+    public DateTime CreatedUtc { get; set; }
+    public DateTime? UpdatedUtc { get; set; }
+}
+
+/// <summary>
+/// A reopened Scenario: the stored inputs and saved snapshot, plus the same inputs recomputed
+/// under today's rules (ADR 0006 - a saved number is never silently changed, and never silently
+/// stale). <see cref="Current"/> is null when the scenario's form is no longer registered.
+/// </summary>
+public class ScenarioDetailDto : ScenarioSummaryDto
+{
+    public CalculationRequest Inputs { get; set; } = new();
+    public CalculationResponse Snapshot { get; set; } = new();
+    public CalculationResponse? Current { get; set; }
+
+    /// <summary>True when today's rules produce a different result than the saved snapshot.</summary>
+    public bool ResultChanged { get; set; }
+}

--- a/src/FairShare.Tests/Api/ScenariosEndpointsTests.cs
+++ b/src/FairShare.Tests/Api/ScenariosEndpointsTests.cs
@@ -1,0 +1,194 @@
+using FairShare.Contracts.Auth;
+using FairShare.Contracts.Calculation;
+using FairShare.Contracts.Scenarios;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace FairShare.Tests.Api;
+
+[Collection("Api")]
+public class ScenariosEndpointsTests : IClassFixture<FairShareApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public ScenariosEndpointsTests(FairShareApiFactory factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+
+    // The CS-42 workbook sample case: defendant pays $50.
+    private static ScenarioSaveRequest AlabamaScenario(string name) => new()
+    {
+        Name = name,
+        State = "AL",
+        Form = "CS42",
+        Inputs = new CalculationRequest
+        {
+            NumberOfChildren = 1,
+            Plaintiff = new ParentDataDto { HasPrimaryCustody = true, MonthlyGrossIncome = 1200, HealthcareCoverageCosts = 100 },
+            Defendant = new ParentDataDto { MonthlyGrossIncome = 1000, WorkRelatedChildcareCosts = 20 }
+        }
+    };
+
+    // The Oregon golden "sole-custody-payer-premium" case: plaintiff pays $506.
+    private static ScenarioSaveRequest OregonScenario(string name) => new()
+    {
+        Name = name,
+        State = "OR",
+        Form = "Worksheet",
+        Inputs = new CalculationRequest
+        {
+            Oregon = new OregonCalculationRequest
+            {
+                Plaintiff = new OregonParentDto { MonthlyIncome = 4500, ChildrensHealthCoverageCost = 250, AverageOvernights = 91 },
+                Defendant = new OregonParentDto { MonthlyIncome = 3200, AverageOvernights = 274 },
+                JointMinorChildren = 2,
+                CashMedical = "No",
+                CoverageSelection = "Plaintiff"
+            }
+        }
+    };
+
+    [Fact]
+    public async Task Scenarios_AsGuest_AreForbidden()
+    {
+        HttpResponseMessage guest = await _client.PostAsync("api/v1/auth/guest", content: null);
+        AuthTokenResponse tokens = (await guest.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+
+        HttpResponseMessage list = await SendAsync(HttpMethod.Get, "api/v1/scenarios", tokens.AccessToken, body: null);
+        HttpResponseMessage save = await SendAsync(HttpMethod.Post, "api/v1/scenarios", tokens.AccessToken, AlabamaScenario("guest-try"));
+
+        Assert.Equal(HttpStatusCode.Forbidden, list.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, save.StatusCode);
+    }
+
+    [Fact]
+    public async Task SaveListReopenDelete_RoundTrip()
+    {
+        string token = await LoginAsAdminAsync();
+
+        // Save an Oregon scenario; the server computes the snapshot itself.
+        HttpResponseMessage saved = await SendAsync(HttpMethod.Post, "api/v1/scenarios", token, OregonScenario("roundtrip-or"));
+        Assert.Equal(HttpStatusCode.Created, saved.StatusCode);
+        ScenarioSummaryDto summary = (await saved.Content.ReadFromJsonAsync<ScenarioSummaryDto>())!;
+
+        Assert.Equal("OR", summary.State);
+        Assert.Equal("Plaintiff", summary.Payer);
+        Assert.Equal(506, summary.FinalAmount);
+        Assert.Equal("2026-07-01", summary.RuleEffectiveDate);
+
+        // It lists.
+        HttpResponseMessage listResponse = await SendAsync(HttpMethod.Get, "api/v1/scenarios", token, body: null);
+        List<ScenarioSummaryDto> list = (await listResponse.Content.ReadFromJsonAsync<List<ScenarioSummaryDto>>())!;
+        Assert.Contains(list, s => s.Id == summary.Id);
+
+        // Reopening recomputes under current rules; nothing changed since save, so no notice.
+        HttpResponseMessage reopened = await SendAsync(HttpMethod.Get, $"api/v1/scenarios/{summary.Id}", token, body: null);
+        Assert.Equal(HttpStatusCode.OK, reopened.StatusCode);
+        ScenarioDetailDto detail = (await reopened.Content.ReadFromJsonAsync<ScenarioDetailDto>())!;
+
+        Assert.False(detail.ResultChanged);
+        Assert.NotNull(detail.Current);
+        Assert.Equal(506, detail.Snapshot.FinalAmount);
+        Assert.Equal(506, detail.Current!.FinalAmount);
+        Assert.Empty(detail.Snapshot.Lines);
+        Assert.NotEmpty(detail.Current.Lines);
+        Assert.Equal(2, detail.Inputs.Oregon!.JointMinorChildren);
+
+        // Delete.
+        HttpResponseMessage deleted = await SendAsync(HttpMethod.Delete, $"api/v1/scenarios/{summary.Id}", token, body: null);
+        Assert.Equal(HttpStatusCode.NoContent, deleted.StatusCode);
+        HttpResponseMessage gone = await SendAsync(HttpMethod.Get, $"api/v1/scenarios/{summary.Id}", token, body: null);
+        Assert.Equal(HttpStatusCode.NotFound, gone.StatusCode);
+    }
+
+    [Fact]
+    public async Task Save_SameName_UpdatesInPlace()
+    {
+        string token = await LoginAsAdminAsync();
+
+        HttpResponseMessage first = await SendAsync(HttpMethod.Post, "api/v1/scenarios", token, AlabamaScenario("upsert-case"));
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+        ScenarioSummaryDto created = (await first.Content.ReadFromJsonAsync<ScenarioSummaryDto>())!;
+
+        // Same name (different case), different figures: updates the same record.
+        ScenarioSaveRequest changed = AlabamaScenario("UPSERT-CASE");
+        changed.Inputs.Defendant.MonthlyGrossIncome = 2000;
+
+        HttpResponseMessage second = await SendAsync(HttpMethod.Post, "api/v1/scenarios", token, changed);
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        ScenarioSummaryDto updated = (await second.Content.ReadFromJsonAsync<ScenarioSummaryDto>())!;
+
+        Assert.Equal(created.Id, updated.Id);
+        Assert.NotEqual(created.FinalAmount, updated.FinalAmount);
+
+        await SendAsync(HttpMethod.Delete, $"api/v1/scenarios/{created.Id}", token, body: null);
+    }
+
+    [Fact]
+    public async Task Save_FailingInputs_IsRejected()
+    {
+        string token = await LoginAsAdminAsync();
+
+        // Overnights not totaling 365 - the worksheet rejects it, so there is no number to preserve.
+        ScenarioSaveRequest bad = OregonScenario("bad-overnights");
+        bad.Inputs.Oregon!.Plaintiff.AverageOvernights = 10;
+
+        HttpResponseMessage response = await SendAsync(HttpMethod.Post, "api/v1/scenarios", token, bad);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Save_UnknownForm_IsNotFound()
+    {
+        string token = await LoginAsAdminAsync();
+
+        ScenarioSaveRequest bad = AlabamaScenario("bogus-form");
+        bad.Form = "BOGUS";
+
+        HttpResponseMessage response = await SendAsync(HttpMethod.Post, "api/v1/scenarios", token, bad);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public void ResultsDiffer_FlagsHeadlineAndOregonTotals()
+    {
+        CalculationResponse baseline = new() { Payer = "Plaintiff", FinalAmount = 506 };
+
+        Assert.False(FairShare.Api.Controllers.ScenariosController.ResultsDiffer(baseline, new() { Payer = "Plaintiff", FinalAmount = 506 }));
+        Assert.True(FairShare.Api.Controllers.ScenariosController.ResultsDiffer(baseline, new() { Payer = "Plaintiff", FinalAmount = 512 }));
+        Assert.True(FairShare.Api.Controllers.ScenariosController.ResultsDiffer(baseline, new() { Payer = "Defendant", FinalAmount = 506 }));
+        Assert.True(FairShare.Api.Controllers.ScenariosController.ResultsDiffer(
+            new() { Payer = "", FinalAmount = 0, Oregon = new OregonResultDto { PlaintiffTotalSupport = 100, DefendantTotalSupport = 200 } },
+            new() { Payer = "", FinalAmount = 0, Oregon = new OregonResultDto { PlaintiffTotalSupport = 100, DefendantTotalSupport = 250 } }));
+    }
+
+    private async Task<string> LoginAsAdminAsync()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync("api/v1/auth/login", new LoginRequest
+        {
+            UserName = "admin",
+            Password = "Adm!n-Test-12345"
+        });
+
+        AuthTokenResponse tokens = (await response.Content.ReadFromJsonAsync<AuthTokenResponse>())!;
+        return tokens.AccessToken;
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, string accessToken, object? body)
+    {
+        using HttpRequestMessage request = new(method, url);
+
+        if (body is not null)
+        {
+            request.Content = JsonContent.Create(body);
+        }
+
+        request.Headers.Add("Authorization", $"Bearer {accessToken}");
+        return await _client.SendAsync(request);
+    }
+}


### PR DESCRIPTION
Part of #130 · Implements [ADR 0006](docs/adr/0006-scenario-recompute-with-notice.md)'s storage and semantics; the UI hook on both state pages follows as the closing slice.

- **`SavedScenario`** — the first state-tagged user data: name, state, form, the full `CalculationRequest` wire JSON (state-agnostic by construction — Alabama and Oregon share the table unchanged), the rule effective date, and a lines-free snapshot of the response the user saw. Strictly owned: cascade-deletes with the account, unique `(OwnerUserId, Name)`, rowversion.
- **`ICalculationRunner`** — the calculation dispatch/mapping extracted from `CalculationsController` into a shared service, because scenarios need to compute in two more places: on **save** (the server computes the snapshot itself; a client-supplied result is never trusted) and on **reopen**.
- **`/api/v1/scenarios`** (`NotGuest` — this is the Oregon page's gated feature): list · save (upsert-by-name like saved parents; inputs the worksheet rejects are **422** — a scenario exists to preserve a number the user saw, and failing inputs have none) · **reopen** (recomputes under *current* rules and sets `ResultChanged` when the headline or either Oregon 9e total moved — a saved figure is never silently changed and never silently stale) · delete. Owner mismatches read as 404, never 403.

**321 tests green** (6 new): guest gating, the Oregon golden-case round-trip (save → list → reopen-with-recompute → delete), case-insensitive upsert, the 422/404 paths, and the `ResultsDiffer` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)