### PR TITLE
feat: Scenario save/load on both calculator pages, list page, nav

### DIFF
--- a/src/FairShare.Web/Components/OregonWorksheet.razor
+++ b/src/FairShare.Web/Components/OregonWorksheet.razor
@@ -85,6 +85,9 @@
     </div>
 }
 
+<ScenarioBar State="@State" Form="@Form" IsGuest="@IsGuest"
+             GetInputs="BuildRequest" OnLoaded="ApplyScenarioAsync" />
+
 @if (jointMinorChildren > 0)
 {
     <OregonOvernightsHelper OnApply="ApplyOvernights" />
@@ -185,6 +188,7 @@
 @code {
     [Parameter, EditorRequired] public string State { get; set; } = string.Empty;
     [Parameter, EditorRequired] public string Form { get; set; } = string.Empty;
+    [Parameter] public bool IsGuest { get; set; }
 
     private readonly OregonParentDto plaintiff = new();
     private readonly OregonParentDto defendant = new();
@@ -207,6 +211,53 @@
     {
         plaintiff.AverageOvernights = overnights.Plaintiff;
         defendant.AverageOvernights = overnights.Defendant;
+    }
+
+    private CalculationRequest BuildRequest() => new()
+    {
+        Oregon = new OregonCalculationRequest
+        {
+            Plaintiff = plaintiff,
+            Defendant = defendant,
+            JointMinorChildren = jointMinorChildren,
+            JointChildrenAttendingSchool = jointChildrenAttendingSchool,
+            CashMedical = cashMedical,
+            CoverageSelection = string.IsNullOrEmpty(coverageSelection) ? null : coverageSelection,
+            OrderCoverageAtHigherAmount = orderCoverageAtHigherAmount
+        }
+    };
+
+    private async Task ApplyScenarioAsync(FairShare.Contracts.Scenarios.ScenarioDetailDto detail)
+    {
+        if (detail.Inputs.Oregon is not { } oregon)
+        {
+            return;
+        }
+
+        CopyParent(oregon.Plaintiff, plaintiff);
+        CopyParent(oregon.Defendant, defendant);
+        jointMinorChildren = oregon.JointMinorChildren;
+        jointChildrenAttendingSchool = oregon.JointChildrenAttendingSchool;
+        cashMedical = oregon.CashMedical;
+        coverageSelection = oregon.CoverageSelection ?? string.Empty;
+        orderCoverageAtHigherAmount = oregon.OrderCoverageAtHigherAmount;
+
+        await CalculateAsync();
+    }
+
+    private static void CopyParent(OregonParentDto from, OregonParentDto into)
+    {
+        into.MonthlyIncome = from.MonthlyIncome;
+        into.SpousalSupportReceived = from.SpousalSupportReceived;
+        into.SpousalSupportPaid = from.SpousalSupportPaid;
+        into.UnionDues = from.UnionDues;
+        into.OwnHealthInsuranceCost = from.OwnHealthInsuranceCost;
+        into.NonJointChildren = from.NonJointChildren;
+        into.ChildCareCosts = from.ChildCareCosts;
+        into.ChildrensHealthCoverageCost = from.ChildrensHealthCoverageCost;
+        into.AverageOvernights = from.AverageOvernights;
+        into.SocialSecurityVeteransBenefits = from.SocialSecurityVeteransBenefits;
+        into.MinimumOrderException = from.MinimumOrderException;
     }
 
     private async Task CalculateAsync()
@@ -236,19 +287,7 @@
 
         try
         {
-            var request = new CalculationRequest
-            {
-                Oregon = new OregonCalculationRequest
-                {
-                    Plaintiff = plaintiff,
-                    Defendant = defendant,
-                    JointMinorChildren = jointMinorChildren,
-                    JointChildrenAttendingSchool = jointChildrenAttendingSchool,
-                    CashMedical = cashMedical,
-                    CoverageSelection = string.IsNullOrEmpty(coverageSelection) ? null : coverageSelection,
-                    OrderCoverageAtHigherAmount = orderCoverageAtHigherAmount
-                }
-            };
+            CalculationRequest request = BuildRequest();
 
             HttpResponseMessage response;
 

--- a/src/FairShare.Web/Components/ScenarioBar.razor
+++ b/src/FairShare.Web/Components/ScenarioBar.razor
@@ -176,6 +176,16 @@
             return;
         }
 
+        // A hand-edited ?scenario= can point at another state or form; applying those inputs
+        // here would be nonsense, so send the user to the scenario's own calculator instead.
+        // (The picker can't mismatch - it lists only this state+form's scenarios.)
+        if (!detail.State.Equals(State, StringComparison.OrdinalIgnoreCase)
+            || !detail.Form.Equals(Form, StringComparison.OrdinalIgnoreCase))
+        {
+            Navigation.NavigateTo($"/States/{detail.State}/{detail.Form}?scenario={detail.Id}");
+            return;
+        }
+
         selectedId = detail.Id.ToString();
         saveName = detail.Name;
 

--- a/src/FairShare.Web/Components/ScenarioBar.razor
+++ b/src/FairShare.Web/Components/ScenarioBar.razor
@@ -16,7 +16,7 @@
                 <select id="ScenarioPicker" class="form-select form-select-sm"
                         value="@(selectedId ?? string.Empty)"
                         @onchange="OnPickedAsync"
-                        disabled="@IsGuest"
+                        disabled="@ControlsDisabled"
                         aria-describedby="@(IsGuest ? "ScenarioGuestHint" : null)">
                     <option value="">-- Load a saved scenario --</option>
                     @foreach (var s in MatchingScenarios)
@@ -28,12 +28,12 @@
             <div class="col-12 col-md-5">
                 <label class="form-label small mb-1" for="ScenarioName">Save current figures as</label>
                 <input id="ScenarioName" class="form-control form-control-sm" @bind="saveName"
-                       maxlength="100" placeholder="e.g. Current schedule" disabled="@IsGuest" />
+                       maxlength="100" placeholder="e.g. Current schedule" disabled="@ControlsDisabled" />
             </div>
             <div class="col-12 col-md-2 d-grid">
                 <button type="button" class="btn btn-outline-primary btn-sm"
                         @onclick="SaveAsync"
-                        disabled="@(IsGuest || saving || string.IsNullOrWhiteSpace(saveName))">
+                        disabled="@(ControlsDisabled || saving || string.IsNullOrWhiteSpace(saveName))">
                     @(saving ? "Saving..." : "Save scenario")
                 </button>
             </div>
@@ -87,6 +87,10 @@
     private string? error;
 
     private string SignInHref => $"/login?returnUrl={Uri.EscapeDataString(new Uri(Navigation.Uri).PathAndQuery)}";
+
+    // A blank form happens transiently on /States/{State} before the redirect to the state's
+    // first form lands; saving or loading against it would hit invalid endpoints.
+    private bool ControlsDisabled => IsGuest || string.IsNullOrEmpty(State) || string.IsNullOrEmpty(Form);
 
     private IEnumerable<ScenarioSummaryDto> MatchingScenarios =>
         scenarios.Where(s => s.State.Equals(State, StringComparison.OrdinalIgnoreCase)

--- a/src/FairShare.Web/Components/ScenarioBar.razor
+++ b/src/FairShare.Web/Components/ScenarioBar.razor
@@ -1,0 +1,255 @@
+@using FairShare.Contracts.Calculation
+@using FairShare.Contracts.Scenarios
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+@* Saved Scenarios (ADR 0006): the save/load bar both state pages embed. A Scenario is a named
+   snapshot of the whole worksheet's inputs; reopening recomputes under today's rules and this bar
+   surfaces the "rules changed since you saved" notice the server reports. Gated: guests see the
+   controls disabled with a sign-in hint, mirroring the saved-parents picker. *@
+
+<div class="card mb-3">
+    <div class="card-body py-2">
+        <div class="row g-2 align-items-end">
+            <div class="col-12 col-md-5">
+                <label class="form-label small mb-1" for="ScenarioPicker">Saved scenarios</label>
+                <select id="ScenarioPicker" class="form-select form-select-sm"
+                        value="@(selectedId ?? string.Empty)"
+                        @onchange="OnPickedAsync"
+                        disabled="@IsGuest"
+                        aria-describedby="@(IsGuest ? "ScenarioGuestHint" : null)">
+                    <option value="">-- Load a saved scenario --</option>
+                    @foreach (var s in MatchingScenarios)
+                    {
+                        <option value="@s.Id">@s.Name (@Headline(s))</option>
+                    }
+                </select>
+            </div>
+            <div class="col-12 col-md-5">
+                <label class="form-label small mb-1" for="ScenarioName">Save current figures as</label>
+                <input id="ScenarioName" class="form-control form-control-sm" @bind="saveName"
+                       maxlength="100" placeholder="e.g. Current schedule" disabled="@IsGuest" />
+            </div>
+            <div class="col-12 col-md-2 d-grid">
+                <button type="button" class="btn btn-outline-primary btn-sm"
+                        @onclick="SaveAsync"
+                        disabled="@(IsGuest || saving || string.IsNullOrWhiteSpace(saveName))">
+                    @(saving ? "Saving..." : "Save scenario")
+                </button>
+            </div>
+        </div>
+
+        @if (IsGuest)
+        {
+            <div id="ScenarioGuestHint" class="form-text mb-0">
+                <a href="@SignInHref">Sign in</a> to save scenarios and plan what-if comparisons.
+            </div>
+        }
+
+        @if (!string.IsNullOrEmpty(status))
+        {
+            <div class="form-text mb-0">@status</div>
+        }
+
+        @if (changedNotice is not null)
+        {
+            @* The ADR 0006 moment: a saved number is never silently changed and never silently
+               stale - when today's rules move it, both figures are shown side by side. *@
+            <div class="alert alert-warning py-2 small mt-2 mb-0" role="alert">@changedNotice</div>
+        }
+
+        @if (!string.IsNullOrEmpty(error))
+        {
+            <div class="alert alert-danger py-2 small mt-2 mb-0" role="alert">@error</div>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public string State { get; set; } = string.Empty;
+    [Parameter, EditorRequired] public string Form { get; set; } = string.Empty;
+    [Parameter] public bool IsGuest { get; set; }
+
+    /// <summary>Builds the page's current inputs for saving.</summary>
+    [Parameter, EditorRequired] public Func<CalculationRequest> GetInputs { get; set; } = () => new();
+
+    /// <summary>Called with the reopened scenario so the page can fill its inputs and recalculate.</summary>
+    [Parameter, EditorRequired] public EventCallback<ScenarioDetailDto> OnLoaded { get; set; }
+
+    private List<ScenarioSummaryDto> scenarios = [];
+    private string? selectedId;
+    private string? saveName;
+    private bool saving;
+    private bool listLoaded;
+    private bool autoLoadDone;
+    private string? status;
+    private string? changedNotice;
+    private string? error;
+
+    private string SignInHref => $"/login?returnUrl={Uri.EscapeDataString(new Uri(Navigation.Uri).PathAndQuery)}";
+
+    private IEnumerable<ScenarioSummaryDto> MatchingScenarios =>
+        scenarios.Where(s => s.State.Equals(State, StringComparison.OrdinalIgnoreCase)
+                          && s.Form.Equals(Form, StringComparison.OrdinalIgnoreCase));
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsGuest || listLoaded)
+        {
+            return;
+        }
+
+        listLoaded = true;
+        await RefreshListAsync();
+
+        // /scenarios links here with ?scenario={id}; load it once on arrival.
+        if (!autoLoadDone && QueryScenarioId() is { } fromQuery)
+        {
+            autoLoadDone = true;
+            await LoadAsync(fromQuery);
+        }
+    }
+
+    private string? QueryScenarioId()
+    {
+        var uri = new Uri(Navigation.Uri);
+        foreach (string pair in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string[] parts = pair.Split('=', 2);
+            if (parts.Length == 2 && parts[0] == "scenario")
+            {
+                return Uri.UnescapeDataString(parts[1]);
+            }
+        }
+
+        return null;
+    }
+
+    private async Task RefreshListAsync()
+    {
+        try
+        {
+            scenarios = await Http.GetFromJsonAsync<List<ScenarioSummaryDto>>("api/v1/scenarios") ?? [];
+        }
+        catch
+        {
+            // An unreachable list only costs the picker; the calculator must keep working.
+            scenarios = [];
+        }
+    }
+
+    private async Task OnPickedAsync(ChangeEventArgs e)
+    {
+        selectedId = e.Value?.ToString();
+
+        if (!string.IsNullOrEmpty(selectedId))
+        {
+            await LoadAsync(selectedId);
+        }
+    }
+
+    private async Task LoadAsync(string id)
+    {
+        error = null;
+        status = null;
+        changedNotice = null;
+
+        ScenarioDetailDto? detail;
+
+        try
+        {
+            detail = await Http.GetFromJsonAsync<ScenarioDetailDto>($"api/v1/scenarios/{id}");
+        }
+        catch
+        {
+            error = "Could not load that scenario.";
+            return;
+        }
+
+        if (detail is null)
+        {
+            error = "Could not load that scenario.";
+            return;
+        }
+
+        selectedId = detail.Id.ToString();
+        saveName = detail.Name;
+
+        if (detail.ResultChanged && detail.Current is not null)
+        {
+            string was = HeadlineText(detail.Snapshot.Payer, detail.Snapshot.FinalAmount);
+            string now = HeadlineText(detail.Current.Payer, detail.Current.FinalAmount);
+            string vintage = detail.RuleEffectiveDate is null ? "" : $" (saved under rules effective {detail.RuleEffectiveDate})";
+
+            changedNotice = $"The rules moved this scenario's result{vintage}: it was {was} when you saved it, and computes as {now} today.";
+        }
+        else
+        {
+            status = $"Loaded \"{detail.Name}\".";
+        }
+
+        await OnLoaded.InvokeAsync(detail);
+    }
+
+    private async Task SaveAsync()
+    {
+        if (saving || string.IsNullOrWhiteSpace(saveName))
+        {
+            return;
+        }
+
+        saving = true;
+        error = null;
+        status = null;
+        changedNotice = null;
+
+        try
+        {
+            ScenarioSaveRequest request = new()
+            {
+                Name = saveName.Trim(),
+                State = State,
+                Form = Form,
+                Inputs = GetInputs()
+            };
+
+            HttpResponseMessage response;
+
+            try
+            {
+                response = await Http.PostAsJsonAsync("api/v1/scenarios", request);
+            }
+            catch (HttpRequestException)
+            {
+                error = "The FairShare API could not be reached. Check your connection and try again.";
+                return;
+            }
+
+            if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+            {
+                error = "These inputs don't produce a result yet - calculate successfully first, then save.";
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                error = $"Saving failed ({(int)response.StatusCode}).";
+                return;
+            }
+
+            ScenarioSummaryDto? saved = await response.Content.ReadFromJsonAsync<ScenarioSummaryDto>();
+            status = $"Saved \"{saved?.Name}\".";
+            await RefreshListAsync();
+            selectedId = saved?.Id.ToString();
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private static string Headline(ScenarioSummaryDto s) => HeadlineText(s.Payer, s.FinalAmount);
+
+    private static string HeadlineText(string payer, int amount)
+        => string.IsNullOrEmpty(payer) ? "no net transfer" : $"{payer} ${amount:N0}/mo";
+}

--- a/src/FairShare.Web/Layout/NavMenu.razor
+++ b/src/FairShare.Web/Layout/NavMenu.razor
@@ -18,6 +18,9 @@
                                 <NavLink class="nav-link" href="profiles">Parents</NavLink>
                             </li>
                             <li class="nav-item">
+                                <NavLink class="nav-link" href="scenarios">Scenarios</NavLink>
+                            </li>
+                            <li class="nav-item">
                                 <NavLink class="nav-link" href="account">Account</NavLink>
                             </li>
                         }

--- a/src/FairShare.Web/Pages/Calculator.razor
+++ b/src/FairShare.Web/Pages/Calculator.razor
@@ -49,7 +49,7 @@
     {
         @* Oregon's inputs don't fit the classic two-parents-plus-child-count surface below; the
            state's whole form lives in its own component. *@
-        <OregonWorksheet State="@State" Form="@(Form ?? string.Empty)" />
+        <OregonWorksheet State="@State" Form="@(Form ?? string.Empty)" IsGuest="isGuest" />
     }
     else
     {
@@ -89,6 +89,12 @@
                 <button class="btn btn-sm btn-outline-secondary" @onclick="() => showImportPrompt = false">Not now</button>
             </span>
         </div>
+    }
+
+    @if (!string.IsNullOrEmpty(Form))
+    {
+        <ScenarioBar State="@State" Form="@Form" IsGuest="isGuest"
+                     GetInputs="BuildScenarioInputs" OnLoaded="ApplyScenarioAsync" />
     }
 
     <div class="row g-4">
@@ -590,6 +596,21 @@
         {
             exporting = false;
         }
+    }
+
+    private CalculationRequest BuildScenarioInputs() => new()
+    {
+        NumberOfChildren = numberOfChildren,
+        Plaintiff = plaintiff,
+        Defendant = defendant
+    };
+
+    private async Task ApplyScenarioAsync(FairShare.Contracts.Scenarios.ScenarioDetailDto detail)
+    {
+        numberOfChildren = detail.Inputs.NumberOfChildren is >= 1 and <= 6 ? detail.Inputs.NumberOfChildren : 1;
+        plaintiff.ApplyFrom(detail.Inputs.Plaintiff);
+        defendant.ApplyFrom(detail.Inputs.Defendant);
+        await CalculateAsync(persistParents: false);
     }
 
     // A flipped Primary Custody switch mirrors onto the other parent (on -> other off, off -> other on).

--- a/src/FairShare.Web/Pages/Scenarios.razor
+++ b/src/FairShare.Web/Pages/Scenarios.razor
@@ -1,0 +1,137 @@
+@page "/scenarios"
+@attribute [Authorize]
+@using FairShare.Contracts.Scenarios
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+
+<PageTitle>FairShare - Scenarios</PageTitle>
+
+<div class="container my-4">
+    <h1 class="h4 mb-4">Scenarios</h1>
+
+    @if (scenarios is null)
+    {
+        <p>Loading...</p>
+    }
+    else if (!scenarios.Any())
+    {
+        @if (string.IsNullOrEmpty(error))
+        {
+            @if (isGuest)
+            {
+                @* "Save one from the calculator" would be false advice for a guest, who cannot save. *@
+                <div class="alert alert-info">
+                    Scenarios are available with an account.
+                    <a href="/login?returnUrl=%2Fscenarios">Sign in</a> to save a worksheet's figures and plan what-if comparisons.
+                </div>
+            }
+            else
+            {
+                <div class="alert alert-info">No saved scenarios yet. Save one from a calculator page.</div>
+            }
+        }
+    }
+    else
+    {
+        <div class="table-responsive">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>State</th>
+                        <th>Result when saved</th>
+                        <th>Rules</th>
+                        <th>Saved</th>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var s in scenarios)
+                    {
+                        <tr>
+                            <td>@s.Name</td>
+                            <td>@s.State</td>
+                            <td>@(string.IsNullOrEmpty(s.Payer) ? "No net transfer" : $"{s.Payer} owes ${s.FinalAmount:N0}/mo")</td>
+                            <td>@(s.RuleEffectiveDate ?? "-")</td>
+                            <td>@((s.UpdatedUtc ?? s.CreatedUtc).ToLocalTime().ToString("yyyy-MM-dd"))</td>
+                            <td class="text-end">
+                                <button class="btn btn-sm btn-outline-primary"
+                                        @onclick="() => Open(s)">Open</button>
+                                <button class="btn btn-sm btn-outline-danger"
+                                        @onclick="() => DeleteAsync(s)">Delete</button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+
+    @if (!string.IsNullOrEmpty(error))
+    {
+        <div class="alert alert-danger">@error</div>
+    }
+</div>
+
+@code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthStateTask { get; set; }
+
+    private List<ScenarioSummaryDto>? scenarios;
+    private bool isGuest;
+    private string? error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthStateTask is not null)
+        {
+            AuthenticationState authState = await AuthStateTask;
+            isGuest = authState.User.HasClaim(c => c.Type == "guest" && c.Value == "true");
+        }
+
+        if (isGuest)
+        {
+            scenarios = [];
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            scenarios = await Http.GetFromJsonAsync<List<ScenarioSummaryDto>>("api/v1/scenarios") ?? [];
+        }
+        catch
+        {
+            scenarios = [];
+            error = "Could not load your scenarios. Check your connection and try again.";
+        }
+    }
+
+    // Opening lands on the scenario's own calculator page; the ScenarioBar there reads the
+    // query parameter and loads it (recomputing under current rules per ADR 0006).
+    private void Open(ScenarioSummaryDto s)
+        => Navigation.NavigateTo($"/States/{s.State}/{s.Form}?scenario={s.Id}");
+
+    private async Task DeleteAsync(ScenarioSummaryDto s)
+    {
+        if (!await JS.InvokeAsync<bool>("confirm", $"Delete the scenario \"{s.Name}\"?"))
+        {
+            return;
+        }
+
+        using HttpResponseMessage response = await Http.DeleteAsync($"api/v1/scenarios/{s.Id}");
+
+        if (response.IsSuccessStatusCode)
+        {
+            scenarios?.RemoveAll(x => x.Id == s.Id);
+        }
+        else
+        {
+            error = $"Delete failed ({(int)response.StatusCode}).";
+        }
+    }
+}

--- a/src/FairShare.Web/Pages/Scenarios.razor
+++ b/src/FairShare.Web/Pages/Scenarios.razor
@@ -123,15 +123,22 @@
             return;
         }
 
-        using HttpResponseMessage response = await Http.DeleteAsync($"api/v1/scenarios/{s.Id}");
+        try
+        {
+            using HttpResponseMessage response = await Http.DeleteAsync($"api/v1/scenarios/{s.Id}");
 
-        if (response.IsSuccessStatusCode)
-        {
-            scenarios?.RemoveAll(x => x.Id == s.Id);
+            if (response.IsSuccessStatusCode)
+            {
+                scenarios?.RemoveAll(x => x.Id == s.Id);
+            }
+            else
+            {
+                error = $"Delete failed ({(int)response.StatusCode}).";
+            }
         }
-        else
+        catch (HttpRequestException)
         {
-            error = $"Delete failed ({(int)response.StatusCode}).";
+            error = "The FairShare API could not be reached. Check your connection and try again.";
         }
     }
 }


### PR DESCRIPTION
Closes #130 · The closing slice (backend: #142).

- **`ScenarioBar`** — the shared save/load bar both state pages embed: a picker filtered to the current state+form, save-as-name (upsert-by-name), and guest-disabled controls with a sign-in hint — Scenarios are the Oregon page's gated feature, mirroring the saved-parents pattern. On reopen it surfaces the **ADR 0006 notice**: when today's rules moved the saved number, both figures appear side by side ("it was Plaintiff $506/mo when you saved it, and computes as ... today"), with the saved rule vintage named. Reads `?scenario={id}` so the list page opens straight into the owning calculator.
- **Calculator (AL)** and **`OregonWorksheet`** embed the bar; loading a scenario fills the page's inputs and recalculates immediately (the request builder is now shared between Calculate and scenario save).
- **`/scenarios`** — the management list: saved-result headline, rule vintage, last-saved date, open + delete-with-confirm; guests get the account invitation, phrased honestly like `/profiles`.
- **Nav**: "Scenarios" beside Parents for signed-in users.

321 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)